### PR TITLE
refactor: 'poneleque' only to declare variables

### DIFF
--- a/src/interpreter.py
+++ b/src/interpreter.py
@@ -186,6 +186,38 @@ class Interpreter:
         
         context.symbol_table.set(var_name, value)
         return res.success(value)
+    
+    def visit_AccessAndAssignNode(self, node: AccessAndAssignNode, context: Context) -> RTResult:
+        """
+        Evaluate an AccessAndAssignNode (variable assignment) in the AST.
+
+        Args:
+            node: The AccessAndAssignNode to evaluate.
+            context: The current execution context.
+
+        Returns:
+            RTResult: A runtime result containing the assigned value.
+        """
+        res = RTResult()
+        var_name = node.var_name_tok.value
+
+        if not context.symbol_table.get(var_name):
+            return res.failure(
+                RTError(
+                    node.pos_start,
+                    node.pos_end,
+                    f"'{var_name}' no está definido",
+                    context
+                )
+            )
+        
+        value = res.register(self.visit(node.value_node, context))
+        
+        if res.should_return():
+            return res
+        
+        context.symbol_table.set(var_name, value)
+        return res.success(value)
 
     def visit_BinOpNode(self, node: BinOpNode, context: Context) -> RTResult:
         """

--- a/src/lunfardo_parser.py
+++ b/src/lunfardo_parser.py
@@ -19,6 +19,7 @@ LunfardoNode = Union[
     MataburrosNode,
     PoneleQueAccessNode,
     PoneleQueAssignNode,
+    AccessAndAssignNode,
     BinOpNode,
     UnaryOpNode,
     SiNode,
@@ -1911,6 +1912,31 @@ class Parser:
                 return res
 
             return res.success(PoneleQueAssignNode(var_name, expr))
+        
+        if self.current_tok.type == TT_IDENTIFIER and self.peek_next_token().type == TT_EQ:
+            var_name = self.current_tok
+
+            res.register_advance()
+            self.advance()
+
+            if self.current_tok.type != TT_EQ:
+                return res.failure(
+                    InvalidSyntaxError(
+                        self.current_tok.pos_start,
+                        self.current_tok.pos_end,
+                        "Se esperaba '='",
+                    )
+                )
+
+            res.register_advance()
+            self.advance()
+
+            expr = res.register(self.expr())
+
+            if res.error:
+                return res
+
+            return res.success(AccessAndAssignNode(var_name, expr))
 
         node = res.register(
             self.bin_op(self.comp_expr, ((TT_KEYWORD, "y"), (TT_KEYWORD, "o")))

--- a/src/nodes.py
+++ b/src/nodes.py
@@ -114,6 +114,25 @@ class PoneleQueAssignNode:
     def __repr__(self) -> str:
         return f'PoneleQueAssignNode({self.var_name_tok}, {self.value_node})'
 
+class AccessAndAssignNode:
+    """Represents a name of a declared variable and its value in the AST."""
+
+    def __init__(self, var_name_tok, value_node) -> None:
+        """
+        Initialize an AccessAndAssignNode.
+
+        Args:
+            var_name_tok (Token): Token representing the name of the variable.
+            value_node (Node): Node representing the value of the variable.
+        """
+        self.var_name_tok = var_name_tok
+        self.value_node = value_node
+        self.pos_start = self.var_name_tok.pos_start
+        self.pos_end = self.value_node.pos_end
+
+    def __repr__(self) -> str:
+        return f'AccessAndAssignNode({self.var_name_tok}, {self.value_node})'
+
     
 class BinOpNode:
     """Represents a Binary Operator in the AST."""


### PR DESCRIPTION
Now in Lunfardo, the keyword 'poneleque' is required only one time at first to declare (and assign) a value.

Later assignments of the same variable are not required to have poneleque keyword.