### PR TITLE
Feature/initial implementation proba sibardea codeblock

### DIFF
--- a/src/builtin/lib/lacompu.py
+++ b/src/builtin/lib/lacompu.py
@@ -88,7 +88,7 @@ def name_adapter(facade):
 
 def environ_adapter(facade):
     value = facade.environ
-    return RTResult().success(Mataburros(value.keys(), value.values()))
+    return RTResult().success(Mataburros.from_dict(value))
 
 def sep_adapter(facade):
     value = facade.sep

--- a/src/constants/keywords.py
+++ b/src/constants/keywords.py
@@ -19,4 +19,6 @@ KEYWORDS = [
     'continuar', # continue
     'rajar', # break
     'importar', # import
+    'proba', # try
+    'sibardea', # except / catch
 ]

--- a/src/constants/keywords.py
+++ b/src/constants/keywords.py
@@ -13,7 +13,7 @@ KEYWORDS = [
     'mientras', # while
     'laburo', # def, func, function
     'cheto', # class
-    'nuevo', # new instance of class
+    'nuevo', # new class instance
     'chau', # end
     'devolver', # return
     'continuar', # continue

--- a/src/errors/errors.py
+++ b/src/errors/errors.py
@@ -22,21 +22,38 @@ class IllegalCharError(Error):
 
     def __init__(self, pos_start, pos_end, details):
         super().__init__(pos_start, pos_end, '\n[Carácter ilegal] Flaco, fijate que metiste un carácter mal', details)
+        self.name = "caracter_ilegal"
 
 class InvalidSyntaxError(Error):
 
     def __init__(self, pos_start, pos_end, details):
         super().__init__(pos_start, pos_end, '\n[Sintaxis inválida] No te entiendo nada, boludo', details)
+        self.name = "sintaxis_invalida"
 
 class ExpectedCharError(Error):
 
     def __init__(self, pos_start, pos_end, details):
         super().__init__(pos_start, pos_end, '\n[Carácter esperado] Flaco, fijate que te olvidaste de un carácter', details)
+        self.name = "caracter_esperado"
 
 class TypeError(Error):
     
     def __init__(self, pos_start, pos_end, details):
         super().__init__(pos_start, pos_end, '\n[Tipo incorrecto] LOCO, ENCIMA TENGO QUE ANDAR MARCANDOTE LOS ERRORES, TARADO', details)
+        self.name = "error_de_tipo"
+
+class ErrorIndex(Error):
+    
+    def __init__(self, pos_start, pos_end, details):
+        super().__init__(pos_start, pos_end, '\n[Error de indice] Dale, una bien te pido nada mas', details)
+        self.name = "error_de_indice"
+
+class ErrorKey(Error):
+    
+    def __init__(self, pos_start, pos_end, details):
+        super().__init__(pos_start, pos_end, '\n[Error de clave] A ver, correte y traeme a alguien que sepa programar (y agarra el mataburros que no muerde)', details)
+        self.name = "error_de_clave"
+
 
 # Run time error
 class RTError(Error):

--- a/src/errors/errors.py
+++ b/src/errors/errors.py
@@ -1,7 +1,7 @@
 from . import string_with_arrows
 from constants.colors import ACCENT, BOLD_ACCENT, DEFAULT
 
-class Error:
+class Bardo:
 
     def __init__(self, pos_start, pos_end, error_name, details):
         self.pos_start = pos_start
@@ -18,48 +18,54 @@ class Error:
         result += f'\n{string_with_arrows(self.pos_start.ftxt, self.pos_start, self.pos_end)}' 
         return result
     
-class IllegalCharError(Error):
+class IllegalCharBardo(Bardo):
 
     def __init__(self, pos_start, pos_end, details):
         super().__init__(pos_start, pos_end, '\n[Carácter ilegal] Flaco, fijate que metiste un carácter mal', details)
         self.name = "caracter_ilegal"
 
-class InvalidSyntaxError(Error):
+class InvalidSyntaxBardo(Bardo):
 
     def __init__(self, pos_start, pos_end, details):
         super().__init__(pos_start, pos_end, '\n[Sintaxis inválida] No te entiendo nada, boludo', details)
         self.name = "sintaxis_invalida"
 
-class ExpectedCharError(Error):
+class ExpectedCharBardo(Bardo):
 
     def __init__(self, pos_start, pos_end, details):
         super().__init__(pos_start, pos_end, '\n[Carácter esperado] Flaco, fijate que te olvidaste de un carácter', details)
         self.name = "caracter_esperado"
 
-class TypeError(Error):
+class InvalidTypeBardo(Bardo):
     
     def __init__(self, pos_start, pos_end, details):
-        super().__init__(pos_start, pos_end, '\n[Tipo incorrecto] LOCO, ENCIMA TENGO QUE ANDAR MARCANDOTE LOS ERRORES, TARADO', details)
-        self.name = "error_de_tipo"
+        super().__init__(pos_start, pos_end, '\n[Bardo de tipo] LOCO, ENCIMA TENGO QUE ANDAR MARCANDOTE LOS BARDOS, TARADO', details)
+        self.name = "bardo_de_tipo"
 
-class ErrorIndex(Error):
+class InvalidIndexBardo(Bardo):
     
     def __init__(self, pos_start, pos_end, details):
-        super().__init__(pos_start, pos_end, '\n[Error de indice] Dale, una bien te pido nada mas', details)
-        self.name = "error_de_indice"
+        super().__init__(pos_start, pos_end, '\n[Bardo de indice] Dale, una bien te pido nada mas', details)
+        self.name = "bardo_de_indice"
 
-class ErrorKey(Error):
+class InvalidKeyBardo(Bardo):
     
     def __init__(self, pos_start, pos_end, details):
-        super().__init__(pos_start, pos_end, '\n[Error de clave] A ver, correte y traeme a alguien que sepa programar (y agarra el mataburros que no muerde)', details)
-        self.name = "error_de_clave"
+        super().__init__(pos_start, pos_end, '\n[Bardo de clave] A ver, correte y traeme a alguien que sepa programar (y agarra el mataburros que no muerde)', details)
+        self.name = "bardo_de_clave"
+
+class InvalidValueBardo(Bardo):
+    
+    def __init__(self, pos_start, pos_end, details):
+        super().__init__(pos_start, pos_end, '\n[Bardo de valor] Sabías que los numeros NO LLEVAN LETRAS?', details)
+        self.name = "bardo_de_valor"
 
 
 # Run time error
-class RTError(Error):
+class RTError(Bardo):
 
     def __init__(self, pos_start, pos_end, details, context):
-        super().__init__(pos_start, pos_end, 'Error en tiempo de ejecución', details)
+        super().__init__(pos_start, pos_end, 'Bardo en tiempo de ejecución', details)
         self.context = context
 
     def as_string(self, nested=False):

--- a/src/interpreter.py
+++ b/src/interpreter.py
@@ -1017,6 +1017,23 @@ class Interpreter:
                 ))
 
         return res.success(Nada.nada)
+    
+    def visit_ProbaSiBardeaNode(self, node: ProbaSiBardeaNode, context: Context) -> RTResult:
+        res = RTResult()
+
+        try_value = res.register(self.visit(node.try_body_node, context))
+        if res.should_return():
+            if res.error.name == node.bardo_name:
+                except_value = res.register(self.visit(node.except_body_node, context))
+                
+                if res.should_return():
+                    return res
+                
+                return res.success(except_value)
+            
+            return res
+        
+        return res.success(try_value)
 
     @staticmethod
     def handle_library_import(lib_name: str, node: ImportarNode, module_context: Context, context: Context) -> RTResult:

--- a/src/interpreter.py
+++ b/src/interpreter.py
@@ -969,7 +969,7 @@ class Interpreter:
             except Exception as e:
                 return res.failure(RTError(
                     node.pos_start, node.pos_end,
-                    f"Error al abrir el fichero '{module_name}'\n" + str(e),
+                    f"Bardo al abrir el fichero '{module_name}'\n" + str(e),
                     context
                 ))
 

--- a/src/lexer.py
+++ b/src/lexer.py
@@ -8,7 +8,7 @@ the parser.
 
 from constants import *
 from lunfardo_token import Position, Token
-from errors.errors import IllegalCharError, ExpectedCharError
+from errors.errors import IllegalCharBardo, ExpectedCharBardo
 from typing import Tuple, List
 
 class Lexer:
@@ -41,7 +41,7 @@ class Lexer:
         self.pos.advance(self.current_char)
         self.current_char = self.text[self.pos.idx] if self.pos.idx < len(self.text) else None
 
-    def make_tokens(self) -> Tuple[List[Token], IllegalCharError | None]:
+    def make_tokens(self) -> Tuple[List[Token], IllegalCharBardo | None]:
         """
         Generate a list of tokens from the input text.
 
@@ -149,7 +149,7 @@ class Lexer:
                 pos_start = self.pos.copy()
                 char = self.current_char
                 self.advance()
-                return [], IllegalCharError(pos_start, self.pos, "'" + char + "'")
+                return [], IllegalCharBardo(pos_start, self.pos, "'" + char + "'")
 
         tokens.append(Token(TT_EOF, pos_start = self.pos))
         return tokens, None
@@ -223,7 +223,7 @@ class Lexer:
         self.advance()
 
         if doublequotes_counter < 2:
-            return None, ExpectedCharError(pos_start, self.pos, 'Se esperaba \'"\'')
+            return None, ExpectedCharBardo(pos_start, self.pos, 'Se esperaba \'"\'')
         
         return Token(TT_STRING, string, pos_start, self.pos), None
     
@@ -244,7 +244,7 @@ class Lexer:
         tok_type = TT_KEYWORD if id_str in KEYWORDS else TT_IDENTIFIER
         return Token(tok_type, id_str, pos_start, self.pos)
     
-    def make_not_equals(self) -> Tuple[Token | None, ExpectedCharError | None]:
+    def make_not_equals(self) -> Tuple[Token | None, ExpectedCharBardo | None]:
         """
         Parse and create a not-equals token.
 
@@ -259,7 +259,7 @@ class Lexer:
             return Token(TT_NE, pos_start = pos_start, pos_end = self.pos), None
         
         self.advance()
-        return None, ExpectedCharError(pos_start, self.pos, "'=' (después de '!')")
+        return None, ExpectedCharBardo(pos_start, self.pos, "'=' (después de '!')")
     
     def make_equals(self) -> Token:
         """

--- a/src/library_registry.py
+++ b/src/library_registry.py
@@ -48,9 +48,9 @@ def init_gualichos(module_context, node, context):
             curro_instance = Curro(name, func)
             module_context.symbol_table.set(name, curro_instance)
     except ImportError as e:
-        return res.failure(RTError(node.pos_start, node.pos_end, f"Error al importar la librería 'gualichos': {str(e)}", context))
+        return res.failure(RTError(node.pos_start, node.pos_end, f"Bardo al importar la librería 'gualichos': {str(e)}", context))
     except AttributeError:
-        return res.failure(RTError(node.pos_start, node.pos_end, f"Error en la librería 'gualichos'", context))
+        return res.failure(RTError(node.pos_start, node.pos_end, "Bardo en la librería 'gualichos'", context))
     return res.success(None)
 
 def init_lacompu(module_context, node, context):
@@ -90,9 +90,9 @@ def init_lacompu(module_context, node, context):
             module_context.symbol_table.set(name, curro_instance)
     
     except ImportError as e:
-        return res.failure(RTError(node.pos_start, node.pos_end, f"Error al importar la librería 'lacompu': {str(e)}", context))
+        return res.failure(RTError(node.pos_start, node.pos_end, f"Bardo al importar la librería 'lacompu': {str(e)}", context))
     except AttributeError:
-        return res.failure(RTError(node.pos_start, node.pos_end, f"Error en la librería 'lacompu'", context))
+        return res.failure(RTError(node.pos_start, node.pos_end, "Bardo en la librería 'lacompu'", context))
     
     return res.success(None)
 

--- a/src/lunfardo_parser.py
+++ b/src/lunfardo_parser.py
@@ -1897,10 +1897,10 @@ class Parser:
             'caracter_ilegal',
             'sintaxis_invalida',
             'caracter_esperado',
-            'error_de_tipo',
-            'error_de_indice',
-            'error_de_clave',
-            'error_de_valor'
+            'bardo_de_tipo',
+            'bardo_de_indice',
+            'bardo_de_clave',
+            'bardo_de_valor'
         )):
             return res.failure(
                 InvalidSyntaxBardo(

--- a/src/lunfardo_parser.py
+++ b/src/lunfardo_parser.py
@@ -8,7 +8,7 @@ It also includes the ParseResult class for managing the parsing process and resu
 
 from constants.tokens import *
 from nodes import *
-from errors import InvalidSyntaxError, TypeError, Error
+from errors import InvalidSyntaxBardo, InvalidTypeBardo, Bardo
 from lunfardo_token import Token
 from typing import Union, Self, Optional, Tuple, Callable
 
@@ -117,7 +117,7 @@ class Parser:
         if not res.error and self.current_tok.type != TT_EOF:
             return (
                 res.failure(
-                    InvalidSyntaxError(
+                    InvalidSyntaxBardo(
                         self.current_tok.pos_start,
                         self.current_tok.pos_end,
                         "Se esperaba '+', '-', '*', '/', '^', '==', '!=', '<', '>', '<=', '>=', 'y' ó 'o'",
@@ -176,7 +176,7 @@ class Parser:
             stmnt = self.statement()
             error_or_statement = res.try_register(stmnt)
 
-            if isinstance(error_or_statement, Error):
+            if isinstance(error_or_statement, Bardo):
                 return res.failure(error_or_statement)
 
             if res.no_result:
@@ -241,7 +241,7 @@ class Parser:
         expr = res.register(self.expr())
         if res.error:
             return res.failure(
-                InvalidSyntaxError(
+                InvalidSyntaxBardo(
                     self.current_tok.pos_start,
                     self.current_tok.pos_end,
                     "Se esperaba 'devolver', 'continuar', 'rajar', 'poneleque', 'si', 'para', 'mientras', 'laburo', numero, identificador, '+', '-', '(', '[' ó 'truchar'",
@@ -284,7 +284,7 @@ class Parser:
                 arg_node = res.register(self.expr())
                 if res.error:
                     return res.failure(
-                        InvalidSyntaxError(
+                        InvalidSyntaxBardo(
                             self.current_tok.pos_start,
                             self.current_tok.pos_end,
                             "Se esperaba ')' o una expresión.",
@@ -304,7 +304,7 @@ class Parser:
                     arg_node = res.register(self.expr())
                     if res.error:
                         return res.failure(
-                            InvalidSyntaxError(
+                            InvalidSyntaxBardo(
                                 self.current_tok.pos_start,
                                 self.current_tok.pos_end,
                                 "Se esperaba ')' o una expresión.",
@@ -315,7 +315,7 @@ class Parser:
 
                 if self.current_tok.type != TT_RPAREN:
                     return res.failure(
-                        InvalidSyntaxError(
+                        InvalidSyntaxBardo(
                             self.current_tok.pos_start,
                             self.current_tok.pos_end,
                             "Se esperaba ',' ó ')'",
@@ -405,7 +405,7 @@ class Parser:
                 return res.success(expr)
 
             return res.failure(
-                InvalidSyntaxError(
+                InvalidSyntaxBardo(
                     self.current_tok.pos_start,
                     self.current_tok.pos_end,
                     "Se esperaba ')'",
@@ -493,7 +493,7 @@ class Parser:
             return res.success(try_expr)
 
         return res.failure(
-            InvalidSyntaxError(
+            InvalidSyntaxBardo(
                 tok.pos_start,
                 tok.pos_end,
                 "Se esperaba número, identificador, '+', '-', '(', '[', 'si', 'para', 'mientras', 'laburo' ó 'cheto'",
@@ -587,7 +587,7 @@ class Parser:
 
         if res.error:
             return res.failure(
-                InvalidSyntaxError(
+                InvalidSyntaxBardo(
                     self.current_tok.pos_start,
                     self.current_tok.pos_end,
                     "Se esperaba numero, identificador, '+', '-', '(', '[' ó truchar'",
@@ -632,7 +632,7 @@ class Parser:
 
         if self.current_tok.type != TT_LSQUARE:
             return res.failure(
-                InvalidSyntaxError(
+                InvalidSyntaxBardo(
                     self.current_tok.pos_start,
                     self.current_tok.pos_end,
                     "Se esperaba '['",
@@ -651,7 +651,7 @@ class Parser:
             expr = res.register(self.expr())
             if res.error:
                 return res.failure(
-                    InvalidSyntaxError(
+                    InvalidSyntaxBardo(
                         self.current_tok.pos_start,
                         self.current_tok.pos_end,
                         "Se esperaba una expresión.",
@@ -667,7 +667,7 @@ class Parser:
                 expr = res.register(self.expr())
                 if res.error:
                     return res.failure(
-                        InvalidSyntaxError(
+                        InvalidSyntaxBardo(
                             self.current_tok.pos_start,
                             self.current_tok.pos_end,
                             "Se esperaba una expresión.",
@@ -678,7 +678,7 @@ class Parser:
 
             if self.current_tok.type != TT_RSQUARE:
                 return res.failure(
-                    InvalidSyntaxError(
+                    InvalidSyntaxBardo(
                         self.current_tok.pos_start,
                         self.current_tok.pos_end,
                         "Se esperaba ']'",
@@ -720,7 +720,7 @@ class Parser:
 
         if self.current_tok.type != TT_LCURLY:
             return res.failure(
-                InvalidSyntaxError(
+                InvalidSyntaxBardo(
                     self.current_tok.pos_start,
                     self.current_tok.pos_end,
                     "Se esperaba '{'",
@@ -740,7 +740,7 @@ class Parser:
             key_expr = self.expr()
             if isinstance(key_expr.node, (CosoNode, MataburrosNode)):
                 return res.failure(
-                    TypeError(
+                    InvalidTypeBardo(
                         self.current_tok.pos_start,
                         self.current_tok.pos_end,
                         "Un coso ó mataburros no puede utilizarse como clave",
@@ -750,7 +750,7 @@ class Parser:
             key_expr = res.register(key_expr)
             if res.error:
                 return res.failure(
-                    InvalidSyntaxError(
+                    InvalidSyntaxBardo(
                         self.current_tok.pos_start,
                         self.current_tok.pos_end,
                         "Se esperaba una clave",
@@ -759,7 +759,7 @@ class Parser:
 
             if not self.current_tok.type == TT_COLON:
                 return res.failure(
-                    InvalidSyntaxError(
+                    InvalidSyntaxBardo(
                         self.current_tok.pos_start,
                         self.current_tok.pos_end,
                         "Se esperaba ':'",
@@ -772,7 +772,7 @@ class Parser:
             value_expr = res.register(self.expr())
             if res.error:
                 return res.failure(
-                    InvalidSyntaxError(
+                    InvalidSyntaxBardo(
                         self.current_tok.pos_start,
                         self.current_tok.pos_end,
                         "Se esperaba un valor",
@@ -793,7 +793,7 @@ class Parser:
                 key_expr = self.expr()
                 if isinstance(key_expr.node, (CosoNode, MataburrosNode)):
                     return res.failure(
-                        TypeError(
+                        InvalidTypeBardo(
                             self.current_tok.pos_start,
                             self.current_tok.pos_end,
                             "Un coso ó mataburros no puede utilizarse como clave",
@@ -803,7 +803,7 @@ class Parser:
                 key_expr = res.register(key_expr)
                 if res.error:
                     return res.failure(
-                        InvalidSyntaxError(
+                        InvalidSyntaxBardo(
                             self.current_tok.pos_start,
                             self.current_tok.pos_end,
                             "Se esperaba una clave",
@@ -812,7 +812,7 @@ class Parser:
                 
                 if not self.current_tok.type == TT_COLON:
                     return res.failure(
-                        InvalidSyntaxError(
+                        InvalidSyntaxBardo(
                             self.current_tok.pos_start,
                             self.current_tok.pos_end,
                             "Se esperaba ':'",
@@ -825,7 +825,7 @@ class Parser:
                 value_expr = res.register(self.expr())
                 if res.error:
                     return res.failure(
-                        InvalidSyntaxError(
+                        InvalidSyntaxBardo(
                             self.current_tok.pos_start,
                             self.current_tok.pos_end,
                             "Se esperaba un valor",
@@ -846,7 +846,7 @@ class Parser:
 
             if not self.current_tok.type == TT_RCURLY:
                 return res.failure(
-                    InvalidSyntaxError(
+                    InvalidSyntaxBardo(
                         self.current_tok.pos_start,
                         self.current_tok.pos_end,
                         "Se esperaba '}'",
@@ -938,7 +938,7 @@ class Parser:
 
                 else:
                     return res.failure(
-                        InvalidSyntaxError(
+                        InvalidSyntaxBardo(
                             self.current_tok.pos_start,
                             self.current_tok.pos_end,
                             "Se esperaba 'chau'",
@@ -1014,7 +1014,7 @@ class Parser:
 
         if not self.current_tok.matches(TT_KEYWORD, case_keyword):
             return res.failure(
-                InvalidSyntaxError(
+                InvalidSyntaxBardo(
                     self.current_tok.pos_start,
                     self.current_tok.pos_end,
                     f"Se esperaba '{case_keyword}'",
@@ -1031,7 +1031,7 @@ class Parser:
 
         if not self.current_tok.matches(TT_KEYWORD, "entonces"):
             return res.failure(
-                InvalidSyntaxError(
+                InvalidSyntaxBardo(
                     self.current_tok.pos_start,
                     self.current_tok.pos_end,
                     "Se esperaba 'entonces'",
@@ -1108,7 +1108,7 @@ class Parser:
 
         if not self.current_tok.matches(TT_KEYWORD, "para"):
             return res.failure(
-                InvalidSyntaxError(
+                InvalidSyntaxBardo(
                     self.current_tok.pos_start,
                     self.current_tok.pos_end,
                     "Se esperaba 'para'",
@@ -1120,7 +1120,7 @@ class Parser:
 
         if self.current_tok.type != TT_IDENTIFIER:
             return res.failure(
-                InvalidSyntaxError(
+                InvalidSyntaxBardo(
                     self.current_tok.pos_start,
                     self.current_tok.pos_end,
                     "Se esperaba identificador",
@@ -1134,7 +1134,7 @@ class Parser:
 
         if self.current_tok.type != TT_EQ:
             return res.failure(
-                InvalidSyntaxError(
+                InvalidSyntaxBardo(
                     self.current_tok.pos_start,
                     self.current_tok.pos_end,
                     "Se esperaba '='",
@@ -1151,7 +1151,7 @@ class Parser:
 
         if not self.current_tok.matches(TT_KEYWORD, "hasta"):
             return res.failure(
-                InvalidSyntaxError(
+                InvalidSyntaxBardo(
                     self.current_tok.pos_start,
                     self.current_tok.pos_end,
                     "Se esperaba 'hasta'",
@@ -1180,7 +1180,7 @@ class Parser:
 
         if not self.current_tok.matches(TT_KEYWORD, "entonces"):
             return res.failure(
-                InvalidSyntaxError(
+                InvalidSyntaxBardo(
                     self.current_tok.pos_start,
                     self.current_tok.pos_end,
                     "Se esperaba 'entonces'",
@@ -1201,7 +1201,7 @@ class Parser:
 
             if not self.current_tok.matches(TT_KEYWORD, "chau"):
                 return res.failure(
-                    InvalidSyntaxError(
+                    InvalidSyntaxBardo(
                         self.current_tok.pos_start,
                         self.current_tok.pos_end,
                         "Se esperaba 'chau'",
@@ -1249,7 +1249,7 @@ class Parser:
 
         if not self.current_tok.matches(TT_KEYWORD, "mientras"):
             return res.failure(
-                InvalidSyntaxError(
+                InvalidSyntaxBardo(
                     self.current_tok.pos_start,
                     self.current_tok.pos_end,
                     "Se esperaba 'mientras'",
@@ -1266,7 +1266,7 @@ class Parser:
 
         if not self.current_tok.matches(TT_KEYWORD, "entonces"):
             return res.failure(
-                InvalidSyntaxError(
+                InvalidSyntaxBardo(
                     self.current_tok.pos_start,
                     self.current_tok.pos_end,
                     "Se esperaba 'entonces'",
@@ -1287,7 +1287,7 @@ class Parser:
 
             if not self.current_tok.matches(TT_KEYWORD, "chau"):
                 return res.failure(
-                    InvalidSyntaxError(
+                    InvalidSyntaxBardo(
                         self.current_tok.pos_start,
                         self.current_tok.pos_end,
                         "Se esperaba 'chau'",
@@ -1335,7 +1335,7 @@ class Parser:
 
         if not self.current_tok.matches(TT_KEYWORD, "laburo"):
             return res.failure(
-                InvalidSyntaxError(
+                InvalidSyntaxBardo(
                     self.current_tok.pos_start,
                     self.current_tok.pos_end,
                     "Se esperaba 'laburo'",
@@ -1347,7 +1347,7 @@ class Parser:
 
         if self.current_tok.type != TT_IDENTIFIER:
             return res.failure(
-                InvalidSyntaxError(
+                InvalidSyntaxBardo(
                     self.current_tok.pos_start,
                     self.current_tok.pos_end,
                     "Se esperaba identificador",
@@ -1360,7 +1360,7 @@ class Parser:
 
         if self.current_tok.type != TT_LPAREN:
             return res.failure(
-                InvalidSyntaxError(
+                InvalidSyntaxBardo(
                     self.current_tok.pos_start,
                     self.current_tok.pos_end,
                     "Se esperaba '('",
@@ -1395,7 +1395,7 @@ class Parser:
 
                 if self.current_tok.type != TT_IDENTIFIER:
                     return res.failure(
-                        InvalidSyntaxError(
+                        InvalidSyntaxBardo(
                             self.current_tok.pos_start,
                             self.current_tok.pos_end,
                             "Se esperaba identificador",
@@ -1420,7 +1420,7 @@ class Parser:
 
         if self.current_tok.type != TT_RPAREN:
             return res.failure(
-                InvalidSyntaxError(
+                InvalidSyntaxBardo(
                     self.current_tok.pos_start,
                     self.current_tok.pos_end,
                     "Se esperaba ')'",
@@ -1432,7 +1432,7 @@ class Parser:
 
         if self.current_tok.type != TT_NEWLINE:
             return res.failure(
-                InvalidSyntaxError(
+                InvalidSyntaxBardo(
                     self.current_tok.pos_start,
                     self.current_tok.pos_end,
                     "Se esperaba nueva línea",
@@ -1448,7 +1448,7 @@ class Parser:
 
         if not self.current_tok.matches(TT_KEYWORD, "chau"):
             return res.failure(
-                InvalidSyntaxError(
+                InvalidSyntaxBardo(
                     self.current_tok.pos_start,
                     self.current_tok.pos_end,
                     "Se esperaba 'chau'",
@@ -1484,7 +1484,7 @@ class Parser:
 
         if not self.current_tok.matches(TT_KEYWORD, "nuevo"):
             return res.failure(
-                InvalidSyntaxError(
+                InvalidSyntaxBardo(
                     self.current_tok.pos_start,
                     self.current_tok.pos_end,
                     "Se esperaba 'nuevo'",
@@ -1496,7 +1496,7 @@ class Parser:
 
         if self.current_tok.type != TT_IDENTIFIER:
             return res.failure(
-                InvalidSyntaxError(
+                InvalidSyntaxBardo(
                     self.current_tok.pos_start,
                     self.current_tok.pos_end,
                     "Se esperaba identificador",
@@ -1520,7 +1520,7 @@ class Parser:
                 expr = res.register(self.expr())
                 if res.error:
                     return res.failure(
-                        InvalidSyntaxError(
+                        InvalidSyntaxBardo(
                             self.current_tok.pos_start,
                             self.current_tok.pos_end,
                             "Se esperaba ')' o una expresión",
@@ -1536,7 +1536,7 @@ class Parser:
                     expr = res.register(self.expr())
                     if res.error:
                         return res.failure(
-                            InvalidSyntaxError(
+                            InvalidSyntaxBardo(
                                 self.current_tok.pos_start,
                                 self.current_tok.pos_end,
                                 "Se esperaba ')' o una expresión",
@@ -1546,7 +1546,7 @@ class Parser:
 
                 if self.current_tok.type != TT_RPAREN:
                     return res.failure(
-                        InvalidSyntaxError(
+                        InvalidSyntaxBardo(
                             self.current_tok.pos_start,
                             self.current_tok.pos_end,
                             "Se esperaba ',' o ')'",
@@ -1584,7 +1584,7 @@ class Parser:
 
         if not self.current_tok.matches(TT_KEYWORD, "cheto"):
             return res.failure(
-                InvalidSyntaxError(
+                InvalidSyntaxBardo(
                     self.current_tok.pos_start,
                     self.current_tok.pos_end,
                     "Se esperaba 'cheto'",
@@ -1596,7 +1596,7 @@ class Parser:
 
         if self.current_tok.type != TT_IDENTIFIER:
             return res.failure(
-                InvalidSyntaxError(
+                InvalidSyntaxBardo(
                     self.current_tok.pos_start,
                     self.current_tok.pos_end,
                     "Se esperaba nombre de cheto",
@@ -1615,7 +1615,7 @@ class Parser:
 
             if self.current_tok.type != TT_IDENTIFIER:
                 return res.failure(
-                    InvalidSyntaxError(
+                    InvalidSyntaxBardo(
                         self.current_tok.pos_start,
                         self.current_tok.pos_end,
                         "Se esperaba identificador",
@@ -1628,7 +1628,7 @@ class Parser:
 
             if self.current_tok.type != TT_RPAREN:
                 return res.failure(
-                    InvalidSyntaxError(
+                    InvalidSyntaxBardo(
                         self.current_tok.pos_start,
                         self.current_tok.pos_end,
                         "Se esperaba ')'",
@@ -1640,7 +1640,7 @@ class Parser:
 
         if self.current_tok.type != TT_NEWLINE:
             return res.failure(
-                InvalidSyntaxError(
+                InvalidSyntaxBardo(
                     self.current_tok.pos_start,
                     self.current_tok.pos_end,
                     "Se esperaba nueva linea despues del nombre de cheto",
@@ -1667,7 +1667,7 @@ class Parser:
                 break
             else:
                 return res.failure(
-                    InvalidSyntaxError(
+                    InvalidSyntaxBardo(
                         self.current_tok.pos_start,
                         self.current_tok.pos_end,
                         "Se esperaba 'laburo' o 'chau'",
@@ -1676,7 +1676,7 @@ class Parser:
 
         if not self.current_tok.matches(TT_KEYWORD, "chau"):
             return res.failure(
-                InvalidSyntaxError(
+                InvalidSyntaxBardo(
                     self.current_tok.pos_start,
                     self.current_tok.pos_end,
                     "Se esperaba 'chau'",
@@ -1715,7 +1715,7 @@ class Parser:
 
         if self.current_tok.type != TT_IDENTIFIER:
             return res.failure(
-                InvalidSyntaxError(
+                InvalidSyntaxBardo(
                     self.current_tok.pos_start,
                     self.current_tok.pos_end,
                     "Se esperaba nombre de metodo",
@@ -1728,7 +1728,7 @@ class Parser:
 
         if self.current_tok.type != TT_LPAREN:
             return res.failure(
-                InvalidSyntaxError(
+                InvalidSyntaxBardo(
                     self.current_tok.pos_start,
                     self.current_tok.pos_end,
                     "Se esperaba '('",
@@ -1746,7 +1746,7 @@ class Parser:
             arg_node = res.register(self.expr())
             if res.error:
                 return res.failure(
-                    InvalidSyntaxError(
+                    InvalidSyntaxBardo(
                         self.current_tok.pos_start,
                         self.current_tok.pos_end,
                         "Se esperaba ')' o una expresión",
@@ -1762,7 +1762,7 @@ class Parser:
                 arg_node = res.register(self.expr())
                 if res.error:
                     return res.failure(
-                        InvalidSyntaxError(
+                        InvalidSyntaxBardo(
                             self.current_tok.pos_start,
                             self.current_tok.pos_end,
                             "Se esperaba una expresión",
@@ -1773,7 +1773,7 @@ class Parser:
 
             if self.current_tok.type != TT_RPAREN:
                 return res.failure(
-                    InvalidSyntaxError(
+                    InvalidSyntaxBardo(
                         self.current_tok.pos_start,
                         self.current_tok.pos_end,
                         "Se esperaba ')'",
@@ -1805,7 +1805,7 @@ class Parser:
 
         if self.current_tok.type != TT_IDENTIFIER:
             return res.failure(
-                InvalidSyntaxError(
+                InvalidSyntaxBardo(
                     self.current_tok.pos_start,
                     self.current_tok.pos_end,
                     "Se esperaba un identificador",
@@ -1829,7 +1829,7 @@ class Parser:
 
         if self.current_tok.type != TT_STRING:
             return res.failure(
-                InvalidSyntaxError(
+                InvalidSyntaxBardo(
                     self.current_tok.pos_start,
                     self.current_tok.pos_end,
                     "El nombre del modulo a importar debe ser un chamuyo",
@@ -1856,7 +1856,7 @@ class Parser:
 
         if self.current_tok.type != TT_COLON:
             return res.failure(
-                InvalidSyntaxError(
+                InvalidSyntaxBardo(
                     self.current_tok.pos_start,
                     self.current_tok.pos_end,
                     "Se esperaba ':'"
@@ -1868,7 +1868,7 @@ class Parser:
         
         if self.current_tok.type != TT_NEWLINE:
             return res.failure(
-                InvalidSyntaxError(
+                InvalidSyntaxBardo(
                     self.current_tok.pos_start,
                     self.current_tok.pos_end,
                     "Se esperaba nueva linea"
@@ -1881,7 +1881,7 @@ class Parser:
         
         if not self.except_keyword_seen:
             return res.failure(
-                InvalidSyntaxError(
+                InvalidSyntaxBardo(
                     self.current_tok.pos_start,
                     self.current_tok.pos_end,
                     "Se esperaba 'sibardea'"
@@ -1898,13 +1898,15 @@ class Parser:
             'sintaxis_invalida',
             'caracter_esperado',
             'error_de_tipo',
-            'error_de_indice'
+            'error_de_indice',
+            'error_de_clave',
+            'error_de_valor'
         )):
             return res.failure(
-                InvalidSyntaxError(
+                InvalidSyntaxBardo(
                     self.current_tok.pos_start,
                     self.current_tok.pos_end,
-                    "Se esperaba 'caracter_ilegal' ó 'sintaxis_invalida' ó 'caracter_esperado' ó 'error_de_tipo' ó 'error_de_indice'"
+                    "Se esperaba un bardo"
                 )
             )
         
@@ -1915,7 +1917,7 @@ class Parser:
 
         if self.current_tok.type != TT_COLON:
             return res.failure(
-                InvalidSyntaxError(
+                InvalidSyntaxBardo(
                     self.current_tok.pos_start,
                     self.current_tok.pos_end,
                     "Se esperaba ':'"
@@ -1927,7 +1929,7 @@ class Parser:
 
         if self.current_tok.type != TT_NEWLINE:
             return res.failure(
-                InvalidSyntaxError(
+                InvalidSyntaxBardo(
                     self.current_tok.pos_start,
                     self.current_tok.pos_end,
                     "Se esperaba nueva linea"
@@ -1978,7 +1980,7 @@ class Parser:
 
             if self.current_tok.type != TT_IDENTIFIER:
                 return res.failure(
-                    InvalidSyntaxError(
+                    InvalidSyntaxBardo(
                         self.current_tok.pos_start,
                         self.current_tok.pos_end,
                         "Se esperaba identificador",
@@ -1996,7 +1998,7 @@ class Parser:
 
                 if self.current_tok.type != TT_IDENTIFIER:
                     return res.failure(
-                        InvalidSyntaxError(
+                        InvalidSyntaxBardo(
                             self.current_tok.pos_start,
                             self.current_tok.pos_end,
                             "Se esperaba identificador",
@@ -2009,7 +2011,7 @@ class Parser:
 
                 if self.current_tok.type != TT_EQ:
                     return res.failure(
-                        InvalidSyntaxError(
+                        InvalidSyntaxBardo(
                             self.current_tok.pos_start,
                             self.current_tok.pos_end,
                             "Se esperaba '='",
@@ -2026,7 +2028,7 @@ class Parser:
 
             if self.current_tok.type != TT_EQ:
                 return res.failure(
-                    InvalidSyntaxError(
+                    InvalidSyntaxBardo(
                         self.current_tok.pos_start,
                         self.current_tok.pos_end,
                         "Se esperaba '='",
@@ -2051,7 +2053,7 @@ class Parser:
 
             if self.current_tok.type != TT_EQ:
                 return res.failure(
-                    InvalidSyntaxError(
+                    InvalidSyntaxBardo(
                         self.current_tok.pos_start,
                         self.current_tok.pos_end,
                         "Se esperaba '='",
@@ -2075,7 +2077,7 @@ class Parser:
         if res.error:
             # MARK: me parece que aca solamente deberia retornar "res"
             return res.failure(
-                InvalidSyntaxError(
+                InvalidSyntaxBardo(
                     self.current_tok.pos_start,
                     self.current_tok.pos_end,
                     "Se esperaba 'poneleque', 'si', 'para', 'mientras', 'laburo', numero, identificador, '+', '-', '(', '[' ó 'truchar'",

--- a/src/lunfardo_types/laburo.py
+++ b/src/lunfardo_types/laburo.py
@@ -472,6 +472,7 @@ class Curro(BaseLaburo):
 
     def exec_sacar(self, exec_ctx):
         from . import Numero, Coso
+        from errors import ErrorIndex
 
         list_ = exec_ctx.symbol_table.get("list")
         index = exec_ctx.symbol_table.get("index")
@@ -500,11 +501,10 @@ class Curro(BaseLaburo):
             popped = list_.elements.pop(index.value)
         except IndexError:
             return RTResult().failure(
-                RTError(
+                ErrorIndex(
                     self.pos_start,
                     self.pos_end,
-                    f"Elemento con el índice {index.value} no pudo ser removido del coso porque el índice está fuera de los límites.",
-                    exec_ctx,
+                    f"Elemento con el índice '{index.value}' no pudo ser removido del coso porque el índice está fuera de los límites."
                 )
             )
 

--- a/src/lunfardo_types/laburo.py
+++ b/src/lunfardo_types/laburo.py
@@ -209,6 +209,7 @@ class Curro(BaseLaburo):
 
     def exec_chamu(self, exec_ctx):
         from . import Chamuyo, Numero, Coso
+        from errors import InvalidTypeBardo
 
         value = exec_ctx.symbol_table.get("value")
 
@@ -233,26 +234,34 @@ class Curro(BaseLaburo):
 
         if isinstance(value, BaseLaburo):
             return RTResult().success(Chamuyo(str(value)))
+        
+        return RTResult().failure(
+            InvalidTypeBardo(
+                value.pos_start,
+                value.pos_end,
+                "El argumento solo puede ser numero, chamuyo, coso o laburo."
+            )
+        )
 
     exec_chamu.arg_names = ["value"]
 
     def exec_num(self, exec_ctx):
         from . import Chamuyo, Numero
+        from errors import InvalidTypeBardo, InvalidValueBardo
 
         value = exec_ctx.symbol_table.get("value")
 
         if not value:
             return RTResult().failure(
-                RTError(
+                InvalidTypeBardo(
                     self.pos_start,
                     self.pos_end,
-                    f"pocos argumentos pasados en '{self.name}'() (esperados 1, recibidos 0)",
-                    exec_ctx,
+                    f"pocos argumentos pasados en '{self.name}'() (esperados 1, recibidos 0)"
                 )
             )
 
         if isinstance(value, Numero):
-            return RTResult().success(Numero(new_value))
+            return RTResult().success(Numero(value.value))
 
         if isinstance(value, Chamuyo):
             # check if string is a valid string
@@ -263,11 +272,10 @@ class Curro(BaseLaburo):
                     new_value = float(value.value)
                 except ValueError:
                     return RTResult().failure(
-                        RTError(
-                            self.pos_start,
-                            self.pos_end,
-                            f"Literal invalido para '{self.name}()' con base 10: '{value.value}'",
-                            exec_ctx,
+                        InvalidValueBardo(
+                            value.pos_start,
+                            value.pos_end,
+                            f"Literal invalido para '{self.name}()' con base 10: '{value.value}'"
                         )
                     )
 
@@ -275,11 +283,10 @@ class Curro(BaseLaburo):
 
         if isinstance(value, BaseLaburo):
             return RTResult().failure(
-                RTError(
-                    self.pos_start,
-                    self.pos_end,
-                    f"El argumento de {self.name}() debe ser un chamuyo o un número, no un 'laburo'",
-                    exec_ctx,
+                InvalidTypeBardo(
+                    value.pos_start,
+                    value.pos_end,
+                    f"El argumento de {self.name}() debe ser un chamuyo o un número, no un 'laburo'"
                 )
             )
 
@@ -365,17 +372,17 @@ class Curro(BaseLaburo):
 
     def exec_guardar(self, exec_ctx):
         from . import Nada, Coso
+        from errors import InvalidTypeBardo
 
         list_ = exec_ctx.symbol_table.get("list")
         value = exec_ctx.symbol_table.get("value")
 
         if not isinstance(list_, Coso):
             return RTResult().failure(
-                RTError(
-                    self.pos_start,
-                    self.pos_end,
-                    "El primer argumento debe ser de tipo coso.",
-                    exec_ctx,
+                InvalidTypeBardo(
+                    list_.pos_start,
+                    list_.pos_end,
+                    "El argumento debe ser de tipo coso"
                 )
             )
 
@@ -386,6 +393,7 @@ class Curro(BaseLaburo):
 
     def exec_insertar(self, exec_ctx):
         from . import Coso, Numero, Nada
+        from errors import InvalidTypeBardo
 
         list_ = exec_ctx.symbol_table.get("list")
         index = exec_ctx.symbol_table.get("index")
@@ -393,21 +401,19 @@ class Curro(BaseLaburo):
 
         if not isinstance(list_, Coso):
             return RTResult().failure(
-                RTError(
-                    self.pos_start,
-                    self.pos_end,
-                    "El primer argumento debe ser de tipo coso.",
-                    exec_ctx,
+                InvalidTypeBardo(
+                    list_.pos_start,
+                    list_.pos_end,
+                    "El argumento debe ser de tipo coso"
                 )
             )
 
         if not isinstance(index, Numero):
             return RTResult().failure(
-                RTError(
-                    self.pos_start,
-                    self.pos_end,
-                    "El segundo argumento debe ser de tipo número.",
-                    exec_ctx,
+                InvalidTypeBardo(
+                    index.pos_start,
+                    index.pos_end,
+                    "El argumento debe ser de tipo numero"
                 )
             )
 
@@ -415,11 +421,10 @@ class Curro(BaseLaburo):
             list_.elements.insert(index.value, value.value)
         except TypeError:
             return RTResult().failure(
-                RTError(
-                    self.pos_start,
-                    self.pos_end,
-                    "El índice debe ser un número entero.",
-                    exec_ctx,
+                InvalidTypeBardo(
+                    index.pos_start,
+                    index.pos_end,
+                    "El argumento debe ser un entero."
                 )
             )
 
@@ -429,6 +434,7 @@ class Curro(BaseLaburo):
 
     def exec_cambiaso(self, exec_ctx):
         from . import Coso, Numero, Nada
+        from errors import InvalidIndexBardo, InvalidTypeBardo
 
         list_ = exec_ctx.symbol_table.get("list")
         index = exec_ctx.symbol_table.get("index")
@@ -436,21 +442,19 @@ class Curro(BaseLaburo):
 
         if not isinstance(list_, Coso):
             return RTResult().failure(
-                RTError(
-                    self.pos_start,
-                    self.pos_end,
-                    "El primer argumento debe ser de tipo coso.",
-                    exec_ctx,
+                InvalidTypeBardo(
+                    list_.pos_start,
+                    list_.pos_end,
+                    "El argumento debe ser de tipo coso"
                 )
             )
 
         if not isinstance(index, Numero):
             return RTResult().failure(
-                RTError(
-                    self.pos_start,
-                    self.pos_end,
-                    "El segundo argumento debe ser de tipo número.",
-                    exec_ctx,
+                InvalidTypeBardo(
+                    index.pos_start,
+                    index.pos_end,
+                    "El argumento debe ser de tipo numero"
                 )
             )
 
@@ -458,11 +462,18 @@ class Curro(BaseLaburo):
             list_.elements[index.value] = value.value
         except TypeError:
             return RTResult().failure(
-                RTError(
-                    self.pos_start,
-                    self.pos_end,
-                    "El índice debe ser un número entero.",
-                    exec_ctx,
+                InvalidTypeBardo(
+                    index.pos_start,
+                    index.pos_end,
+                    "El argumento debe ser un entero."
+                )
+            )
+        except IndexError:
+            return RTResult().failure(
+                InvalidIndexBardo(
+                    index.pos_start,
+                    index.pos_end,
+                    f"Elemento con el índice '{index.value}' no pudo ser reemplazado del coso porque el índice está fuera de los límites."
                 )
             )
 
@@ -472,28 +483,26 @@ class Curro(BaseLaburo):
 
     def exec_sacar(self, exec_ctx):
         from . import Numero, Coso
-        from errors import ErrorIndex
+        from errors import InvalidIndexBardo, InvalidTypeBardo
 
         list_ = exec_ctx.symbol_table.get("list")
         index = exec_ctx.symbol_table.get("index")
 
         if not isinstance(list_, Coso):
             return RTResult().failure(
-                RTError(
-                    self.pos_start,
-                    self.pos_end,
-                    "El primer argumento debe ser de tipo coso.",
-                    exec_ctx,
+                InvalidTypeBardo(
+                    list_.pos_start,
+                    list_.pos_end,
+                    "El argumento debe ser de tipo coso."
                 )
             )
 
         if not isinstance(index, Numero):
             return RTResult().failure(
-                RTError(
-                    self.pos_start,
-                    self.pos_end,
-                    "El segundo argumento debe ser de tipo número.",
-                    exec_ctx,
+                InvalidTypeBardo(
+                    index.pos_start,
+                    index.pos_end,
+                    "El argumento debe ser de tipo numero."
                 )
             )
 
@@ -501,7 +510,7 @@ class Curro(BaseLaburo):
             popped = list_.elements.pop(index.value)
         except IndexError:
             return RTResult().failure(
-                ErrorIndex(
+                InvalidIndexBardo(
                     self.pos_start,
                     self.pos_end,
                     f"Elemento con el índice '{index.value}' no pudo ser removido del coso porque el índice está fuera de los límites."
@@ -514,27 +523,26 @@ class Curro(BaseLaburo):
 
     def exec_extender(self, exec_ctx):
         from . import Nada, Coso
+        from errors import InvalidTypeBardo
 
         listA = exec_ctx.symbol_table.get("listA")
         listB = exec_ctx.symbol_table.get("listB")
 
         if not isinstance(listA, Coso):
             return RTResult().failure(
-                RTError(
-                    self.pos_start,
-                    self.pos_end,
-                    "El primer argumento debe ser de tipo coso.",
-                    exec_ctx,
+                InvalidTypeBardo(
+                    listA.pos_start,
+                    listA.pos_end,
+                    "El argumento debe ser de tipo coso."
                 )
             )
 
         if not isinstance(listB, Coso):
             return RTResult().failure(
-                RTError(
-                    self.pos_start,
-                    self.pos_end,
-                    "El segundo argumento debe ser de tipo coso.",
-                    exec_ctx,
+                InvalidTypeBardo(
+                    listB.pos_start,
+                    listB.pos_end,
+                    "El argumento debe ser de tipo coso."
                 )
             )
 
@@ -546,27 +554,26 @@ class Curro(BaseLaburo):
 
     def exec_agarra_de(self, exec_ctx):
         from . import Chamuyo, Numero, Mataburros, Nada
+        from errors import InvalidTypeBardo
 
         dict_ = exec_ctx.symbol_table.get("dict")
         key = exec_ctx.symbol_table.get("key")
 
         if not isinstance(dict_, Mataburros):
             return RTResult().failure(
-                RTError(
-                    self.pos_start,
-                    self.pos_end,
-                    "El primer argumento debe ser de tipo mataburros.",
-                    exec_ctx,
+                InvalidTypeBardo(
+                    dict_.pos_start,
+                    dict_.pos_end,
+                    "El argumento debe ser de tipo mataburros"
                 )
             )
 
         if not isinstance(key, (Numero, Chamuyo)):
             return RTResult().failure(
-                RTError(
-                    self.pos_start,
-                    self.pos_end,
-                    "El segundo argumento debe ser de tipo número o chamuyo.",
-                    exec_ctx,
+                InvalidTypeBardo(
+                    key.pos_start,
+                    key.pos_end,
+                    "El argumento debe ser de tipo numero o chamuyo."
                 )
             )
 
@@ -580,6 +587,7 @@ class Curro(BaseLaburo):
 
     def exec_metele_en(self, exec_ctx):
         from . import Chamuyo, Numero, Mataburros, Nada
+        from errors import InvalidTypeBardo
 
         dict_ = exec_ctx.symbol_table.get("dict")
         key = exec_ctx.symbol_table.get("key")
@@ -587,21 +595,19 @@ class Curro(BaseLaburo):
 
         if not isinstance(dict_, Mataburros):
             return RTResult().failure(
-                RTError(
-                    self.pos_start,
-                    self.pos_end,
-                    "El primer argumento debe ser de tipo mataburros.",
-                    exec_ctx,
+                InvalidTypeBardo(
+                    dict_.pos_start,
+                    dict_.pos_end,
+                    "El argumento debe ser de tipo mataburros"
                 )
             )
 
         if not isinstance(key, (Numero, Chamuyo)):
             return RTResult().failure(
-                RTError(
-                    self.pos_start,
-                    self.pos_end,
-                    "El segundo argumento debe ser de tipo número o chamuyo.",
-                    exec_ctx,
+                InvalidTypeBardo(
+                    key.pos_start,
+                    key.pos_end,
+                    "El argumento debe ser de tipo numero o chamuyo."
                 )
             )
 
@@ -612,27 +618,26 @@ class Curro(BaseLaburo):
 
     def exec_borra_de(self, exec_ctx):
         from . import Chamuyo, Numero, Mataburros, Nada
+        from errors import InvalidTypeBardo, InvalidKeyBardo
 
         dict_ = exec_ctx.symbol_table.get("dict")
         key = exec_ctx.symbol_table.get("key")
 
         if not isinstance(dict_, Mataburros):
             return RTResult().failure(
-                RTError(
-                    self.pos_start,
-                    self.pos_end,
-                    "El primer argumento debe ser de tipo mataburros.",
-                    exec_ctx,
+                InvalidTypeBardo(
+                    dict_.pos_start,
+                    dict_.pos_end,
+                    "El argumento debe ser de tipo mataburros"
                 )
             )
 
         if not isinstance(key, (Numero, Chamuyo)):
             return RTResult().failure(
-                RTError(
-                    self.pos_start,
-                    self.pos_end,
-                    "El segundo argumento debe ser de tipo número o chamuyo.",
-                    exec_ctx,
+                InvalidTypeBardo(
+                    key.pos_start,
+                    key.pos_end,
+                    "El argumento debe ser de tipo numero o chamuyo."
                 )
             )
 
@@ -641,39 +646,37 @@ class Curro(BaseLaburo):
             return RTResult().success(Nada.nada)
         
         return RTResult().failure(
-            RTError(
-                self.pos_start,
-                self.pos_end,
-                f"El elemento con la clave {key} no pudo ser encontrado en el mataburros.",
-                exec_ctx,
+            InvalidKeyBardo(
+                key.pos_start,
+                key.pos_end,
+                f"El elemento con la clave {key} no pudo ser encontrado en el mataburros."
             )
         )
 
     exec_borra_de.arg_names = ["dict", "key"]
 
     def exec_existe_clave(self, exec_ctx):
-        from . import Chamuyo, Numero, Mataburros, Laburo, Curro, Nada, Boloodean
+        from . import Chamuyo, Numero, Mataburros, Nada, Boloodean
+        from errors import InvalidTypeBardo
 
         dict_ = exec_ctx.symbol_table.get("dict")
         key = exec_ctx.symbol_table.get("key")
 
         if not isinstance(dict_, Mataburros):
             return RTResult().failure(
-                RTError(
-                    self.pos_start,
-                    self.pos_end,
-                    "El primer argumento debe ser de tipo mataburros.",
-                    exec_ctx,
+                InvalidTypeBardo(
+                    dict_.pos_start,
+                    dict_.pos_end,
+                    "El argumento debe ser de tipo mataburros"
                 )
             )
 
-        if not isinstance(key, (Numero, Chamuyo, Laburo, Curro)):
+        if not isinstance(key, (Numero, Chamuyo, Nada, Boloodean)):
             return RTResult().failure(
-                RTError(
-                    self.pos_start,
-                    self.pos_end,
-                    "El segundo argumento no puede ser de tipo Coso ó Mataburros.",
-                    exec_ctx,
+                InvalidTypeBardo(
+                    key.pos_start,
+                    key.pos_end,
+                    "El argumento debe ser de tipo numero, chamuyo, nada o boloodean"
                 )
             )
 
@@ -686,16 +689,16 @@ class Curro(BaseLaburo):
 
     def exec_longitud(self, exec_ctx):
         from . import Numero, Coso, Mataburros, Chamuyo, Nada
+        from errors import InvalidTypeBardo
 
         arg = exec_ctx.symbol_table.get("arg")
 
         if not isinstance(arg, (Coso, Mataburros, Chamuyo)):
             return RTResult().failure(
-                RTError(
-                    self.pos_start,
-                    self.pos_end,
-                    "El argumento debe ser de tipo coso, mataburros o chamuyo.",
-                    exec_ctx,
+                InvalidTypeBardo(
+                    arg.pos_start,
+                    arg.pos_end,
+                    "El argumento debe ser de tipo coso, chamuyo o mataburros"
                 )
             )
 
@@ -714,16 +717,16 @@ class Curro(BaseLaburo):
 
     def exec_ejecutar(self, exec_ctx):
         from . import Chamuyo, Nada
+        from errors import InvalidTypeBardo
 
         fn = exec_ctx.symbol_table.get("fn")
 
         if not isinstance(fn, Chamuyo):
             return RTResult().failure(
-                RTError(
-                    self.pos_start,
-                    self.pos_end,
-                    "El primer argumento debe ser de tipo chamuyo.",
-                    exec_ctx,
+                InvalidTypeBardo(
+                    fn.pos_start,
+                    fn.pos_end,
+                    "El argumento debe ser de tipo chamuyo"
                 )
             )
 
@@ -774,7 +777,7 @@ class Curro(BaseLaburo):
     exec_renuncio.arg_names = []
 
     def exec_contexto_global(self, exec_ctx):
-        from . import Mataburros, Boloodean, Chamuyo
+        from . import Mataburros, Boloodean
 
         _local = exec_ctx.symbol_table.get("local")
         if isinstance(_local, Boloodean):
@@ -792,19 +795,21 @@ class Curro(BaseLaburo):
 
     def exec_asciiAchamu(self, exec_ctx):
         from . import Chamuyo, Numero
+        from errors import InvalidTypeBardo
 
         code = exec_ctx.symbol_table.get("ascii_code")
         if not isinstance(code, Numero):
             return RTResult().failure(
-                RTError(
-                    self.pos_start,
-                    self.pos_end,
-                    "El argumento debe ser de tipo número.",
-                    exec_ctx,
+                InvalidTypeBardo(
+                    code.pos_start,
+                    code.pos_end,
+                    "El argumento debe ser de tipo numero"
                 )
             )
+        
+        code = int(code.value)
 
-        return RTResult().success(Chamuyo(chr(code.value)))
+        return RTResult().success(Chamuyo(chr(code)))
     
     exec_asciiAchamu.arg_names = ['ascii_code']
 

--- a/src/nodes.py
+++ b/src/nodes.py
@@ -481,3 +481,26 @@ class ImportarNode:
     
     def __str__(self) -> str:
         return f'ImportarNode({self.module_name_node})'
+    
+class ProbaSiBardeaNode:
+    """ Represents a try-except code block in the AST """
+
+    def __init__(self, try_body_node, bardo_name, except_body_node) -> None:
+        """
+        Initialize a ProbaSiBardeaNode.
+
+        Args:
+            try_body (Node): Node representing the node to try
+            except_body (Node): Node representing the node to execute in case of Bardo (exception)
+        """
+        self.try_body_node = try_body_node
+        self.except_body_node = except_body_node
+        self.bardo_name = bardo_name
+        self.pos_start = self.try_body_node.pos_start
+        self.pos_end = self.except_body_node.pos_end
+
+    def __repr__(self) -> str:
+        return f'ProbaSiBardeaNode({self.try_body_node}, {self.except_body_node})'
+    
+    def __str__(self) -> str:
+        return f'ProbaSiBardeaNode({self.try_body_node}, {self.except_body_node})'


### PR DESCRIPTION
## Features
- proba-sibardea code block (equivalent to try-except block). Currently limited to one except block.
- updated errors, now named "bardos".

## Chore
- updated a single comment in keywords.py for clarity.
- updated lacompu.py to fit mataburros new implementation.

## Bugfix
- errors (now bardos) won't propagate at the end of a codeblock: now it should propagate every error, although it will still be monitored.