### PR TITLE
Release/proba sibardea code block

### DIFF
--- a/src/builtin/lib/lacompu.py
+++ b/src/builtin/lib/lacompu.py
@@ -88,7 +88,7 @@ def name_adapter(facade):
 
 def environ_adapter(facade):
     value = facade.environ
-    return RTResult().success(Mataburros(value.keys(), value.values()))
+    return RTResult().success(Mataburros.from_dict(value))
 
 def sep_adapter(facade):
     value = facade.sep

--- a/src/constants/keywords.py
+++ b/src/constants/keywords.py
@@ -13,10 +13,12 @@ KEYWORDS = [
     'mientras', # while
     'laburo', # def, func, function
     'cheto', # class
-    'nuevo', # new instance of class
+    'nuevo', # new class instance
     'chau', # end
     'devolver', # return
     'continuar', # continue
     'rajar', # break
     'importar', # import
+    'proba', # try
+    'sibardea', # except / catch
 ]

--- a/src/errors/errors.py
+++ b/src/errors/errors.py
@@ -1,7 +1,7 @@
 from . import string_with_arrows
 from constants.colors import ACCENT, BOLD_ACCENT, DEFAULT
 
-class Error:
+class Bardo:
 
     def __init__(self, pos_start, pos_end, error_name, details):
         self.pos_start = pos_start
@@ -18,31 +18,54 @@ class Error:
         result += f'\n{string_with_arrows(self.pos_start.ftxt, self.pos_start, self.pos_end)}' 
         return result
     
-class IllegalCharError(Error):
+class IllegalCharBardo(Bardo):
 
     def __init__(self, pos_start, pos_end, details):
         super().__init__(pos_start, pos_end, '\n[Carácter ilegal] Flaco, fijate que metiste un carácter mal', details)
+        self.name = "caracter_ilegal"
 
-class InvalidSyntaxError(Error):
+class InvalidSyntaxBardo(Bardo):
 
     def __init__(self, pos_start, pos_end, details):
         super().__init__(pos_start, pos_end, '\n[Sintaxis inválida] No te entiendo nada, boludo', details)
+        self.name = "sintaxis_invalida"
 
-class ExpectedCharError(Error):
+class ExpectedCharBardo(Bardo):
 
     def __init__(self, pos_start, pos_end, details):
         super().__init__(pos_start, pos_end, '\n[Carácter esperado] Flaco, fijate que te olvidaste de un carácter', details)
+        self.name = "caracter_esperado"
 
-class TypeError(Error):
+class InvalidTypeBardo(Bardo):
     
     def __init__(self, pos_start, pos_end, details):
-        super().__init__(pos_start, pos_end, '\n[Tipo incorrecto] LOCO, ENCIMA TENGO QUE ANDAR MARCANDOTE LOS ERRORES, TARADO', details)
+        super().__init__(pos_start, pos_end, '\n[Bardo de tipo] LOCO, ENCIMA TENGO QUE ANDAR MARCANDOTE LOS BARDOS, TARADO', details)
+        self.name = "bardo_de_tipo"
+
+class InvalidIndexBardo(Bardo):
+    
+    def __init__(self, pos_start, pos_end, details):
+        super().__init__(pos_start, pos_end, '\n[Bardo de indice] Dale, una bien te pido nada mas', details)
+        self.name = "bardo_de_indice"
+
+class InvalidKeyBardo(Bardo):
+    
+    def __init__(self, pos_start, pos_end, details):
+        super().__init__(pos_start, pos_end, '\n[Bardo de clave] A ver, correte y traeme a alguien que sepa programar (y agarra el mataburros que no muerde)', details)
+        self.name = "bardo_de_clave"
+
+class InvalidValueBardo(Bardo):
+    
+    def __init__(self, pos_start, pos_end, details):
+        super().__init__(pos_start, pos_end, '\n[Bardo de valor] Sabías que los numeros NO LLEVAN LETRAS?', details)
+        self.name = "bardo_de_valor"
+
 
 # Run time error
-class RTError(Error):
+class RTError(Bardo):
 
     def __init__(self, pos_start, pos_end, details, context):
-        super().__init__(pos_start, pos_end, 'Error en tiempo de ejecución', details)
+        super().__init__(pos_start, pos_end, 'Bardo en tiempo de ejecución', details)
         self.context = context
 
     def as_string(self, nested=False):

--- a/src/interpreter.py
+++ b/src/interpreter.py
@@ -969,7 +969,7 @@ class Interpreter:
             except Exception as e:
                 return res.failure(RTError(
                     node.pos_start, node.pos_end,
-                    f"Error al abrir el fichero '{module_name}'\n" + str(e),
+                    f"Bardo al abrir el fichero '{module_name}'\n" + str(e),
                     context
                 ))
 
@@ -1017,6 +1017,23 @@ class Interpreter:
                 ))
 
         return res.success(Nada.nada)
+    
+    def visit_ProbaSiBardeaNode(self, node: ProbaSiBardeaNode, context: Context) -> RTResult:
+        res = RTResult()
+
+        try_value = res.register(self.visit(node.try_body_node, context))
+        if res.should_return():
+            if res.error.name == node.bardo_name:
+                except_value = res.register(self.visit(node.except_body_node, context))
+                
+                if res.should_return():
+                    return res
+                
+                return res.success(except_value)
+            
+            return res
+        
+        return res.success(try_value)
 
     @staticmethod
     def handle_library_import(lib_name: str, node: ImportarNode, module_context: Context, context: Context) -> RTResult:

--- a/src/lexer.py
+++ b/src/lexer.py
@@ -8,7 +8,7 @@ the parser.
 
 from constants import *
 from lunfardo_token import Position, Token
-from errors.errors import IllegalCharError, ExpectedCharError
+from errors.errors import IllegalCharBardo, ExpectedCharBardo
 from typing import Tuple, List
 
 class Lexer:
@@ -41,7 +41,7 @@ class Lexer:
         self.pos.advance(self.current_char)
         self.current_char = self.text[self.pos.idx] if self.pos.idx < len(self.text) else None
 
-    def make_tokens(self) -> Tuple[List[Token], IllegalCharError | None]:
+    def make_tokens(self) -> Tuple[List[Token], IllegalCharBardo | None]:
         """
         Generate a list of tokens from the input text.
 
@@ -149,7 +149,7 @@ class Lexer:
                 pos_start = self.pos.copy()
                 char = self.current_char
                 self.advance()
-                return [], IllegalCharError(pos_start, self.pos, "'" + char + "'")
+                return [], IllegalCharBardo(pos_start, self.pos, "'" + char + "'")
 
         tokens.append(Token(TT_EOF, pos_start = self.pos))
         return tokens, None
@@ -223,7 +223,7 @@ class Lexer:
         self.advance()
 
         if doublequotes_counter < 2:
-            return None, ExpectedCharError(pos_start, self.pos, 'Se esperaba \'"\'')
+            return None, ExpectedCharBardo(pos_start, self.pos, 'Se esperaba \'"\'')
         
         return Token(TT_STRING, string, pos_start, self.pos), None
     
@@ -244,7 +244,7 @@ class Lexer:
         tok_type = TT_KEYWORD if id_str in KEYWORDS else TT_IDENTIFIER
         return Token(tok_type, id_str, pos_start, self.pos)
     
-    def make_not_equals(self) -> Tuple[Token | None, ExpectedCharError | None]:
+    def make_not_equals(self) -> Tuple[Token | None, ExpectedCharBardo | None]:
         """
         Parse and create a not-equals token.
 
@@ -259,7 +259,7 @@ class Lexer:
             return Token(TT_NE, pos_start = pos_start, pos_end = self.pos), None
         
         self.advance()
-        return None, ExpectedCharError(pos_start, self.pos, "'=' (después de '!')")
+        return None, ExpectedCharBardo(pos_start, self.pos, "'=' (después de '!')")
     
     def make_equals(self) -> Token:
         """

--- a/src/library_registry.py
+++ b/src/library_registry.py
@@ -48,9 +48,9 @@ def init_gualichos(module_context, node, context):
             curro_instance = Curro(name, func)
             module_context.symbol_table.set(name, curro_instance)
     except ImportError as e:
-        return res.failure(RTError(node.pos_start, node.pos_end, f"Error al importar la librería 'gualichos': {str(e)}", context))
+        return res.failure(RTError(node.pos_start, node.pos_end, f"Bardo al importar la librería 'gualichos': {str(e)}", context))
     except AttributeError:
-        return res.failure(RTError(node.pos_start, node.pos_end, f"Error en la librería 'gualichos'", context))
+        return res.failure(RTError(node.pos_start, node.pos_end, "Bardo en la librería 'gualichos'", context))
     return res.success(None)
 
 def init_lacompu(module_context, node, context):
@@ -90,9 +90,9 @@ def init_lacompu(module_context, node, context):
             module_context.symbol_table.set(name, curro_instance)
     
     except ImportError as e:
-        return res.failure(RTError(node.pos_start, node.pos_end, f"Error al importar la librería 'lacompu': {str(e)}", context))
+        return res.failure(RTError(node.pos_start, node.pos_end, f"Bardo al importar la librería 'lacompu': {str(e)}", context))
     except AttributeError:
-        return res.failure(RTError(node.pos_start, node.pos_end, f"Error en la librería 'lacompu'", context))
+        return res.failure(RTError(node.pos_start, node.pos_end, "Bardo en la librería 'lacompu'", context))
     
     return res.success(None)
 

--- a/src/lunfardo_types/laburo.py
+++ b/src/lunfardo_types/laburo.py
@@ -209,6 +209,7 @@ class Curro(BaseLaburo):
 
     def exec_chamu(self, exec_ctx):
         from . import Chamuyo, Numero, Coso
+        from errors import InvalidTypeBardo
 
         value = exec_ctx.symbol_table.get("value")
 
@@ -233,26 +234,34 @@ class Curro(BaseLaburo):
 
         if isinstance(value, BaseLaburo):
             return RTResult().success(Chamuyo(str(value)))
+        
+        return RTResult().failure(
+            InvalidTypeBardo(
+                value.pos_start,
+                value.pos_end,
+                "El argumento solo puede ser numero, chamuyo, coso o laburo."
+            )
+        )
 
     exec_chamu.arg_names = ["value"]
 
     def exec_num(self, exec_ctx):
         from . import Chamuyo, Numero
+        from errors import InvalidTypeBardo, InvalidValueBardo
 
         value = exec_ctx.symbol_table.get("value")
 
         if not value:
             return RTResult().failure(
-                RTError(
+                InvalidTypeBardo(
                     self.pos_start,
                     self.pos_end,
-                    f"pocos argumentos pasados en '{self.name}'() (esperados 1, recibidos 0)",
-                    exec_ctx,
+                    f"pocos argumentos pasados en '{self.name}'() (esperados 1, recibidos 0)"
                 )
             )
 
         if isinstance(value, Numero):
-            return RTResult().success(Numero(new_value))
+            return RTResult().success(Numero(value.value))
 
         if isinstance(value, Chamuyo):
             # check if string is a valid string
@@ -263,11 +272,10 @@ class Curro(BaseLaburo):
                     new_value = float(value.value)
                 except ValueError:
                     return RTResult().failure(
-                        RTError(
-                            self.pos_start,
-                            self.pos_end,
-                            f"Literal invalido para '{self.name}()' con base 10: '{value.value}'",
-                            exec_ctx,
+                        InvalidValueBardo(
+                            value.pos_start,
+                            value.pos_end,
+                            f"Literal invalido para '{self.name}()' con base 10: '{value.value}'"
                         )
                     )
 
@@ -275,11 +283,10 @@ class Curro(BaseLaburo):
 
         if isinstance(value, BaseLaburo):
             return RTResult().failure(
-                RTError(
-                    self.pos_start,
-                    self.pos_end,
-                    f"El argumento de {self.name}() debe ser un chamuyo o un número, no un 'laburo'",
-                    exec_ctx,
+                InvalidTypeBardo(
+                    value.pos_start,
+                    value.pos_end,
+                    f"El argumento de {self.name}() debe ser un chamuyo o un número, no un 'laburo'"
                 )
             )
 
@@ -365,17 +372,17 @@ class Curro(BaseLaburo):
 
     def exec_guardar(self, exec_ctx):
         from . import Nada, Coso
+        from errors import InvalidTypeBardo
 
         list_ = exec_ctx.symbol_table.get("list")
         value = exec_ctx.symbol_table.get("value")
 
         if not isinstance(list_, Coso):
             return RTResult().failure(
-                RTError(
-                    self.pos_start,
-                    self.pos_end,
-                    "El primer argumento debe ser de tipo coso.",
-                    exec_ctx,
+                InvalidTypeBardo(
+                    list_.pos_start,
+                    list_.pos_end,
+                    "El argumento debe ser de tipo coso"
                 )
             )
 
@@ -386,6 +393,7 @@ class Curro(BaseLaburo):
 
     def exec_insertar(self, exec_ctx):
         from . import Coso, Numero, Nada
+        from errors import InvalidTypeBardo
 
         list_ = exec_ctx.symbol_table.get("list")
         index = exec_ctx.symbol_table.get("index")
@@ -393,21 +401,19 @@ class Curro(BaseLaburo):
 
         if not isinstance(list_, Coso):
             return RTResult().failure(
-                RTError(
-                    self.pos_start,
-                    self.pos_end,
-                    "El primer argumento debe ser de tipo coso.",
-                    exec_ctx,
+                InvalidTypeBardo(
+                    list_.pos_start,
+                    list_.pos_end,
+                    "El argumento debe ser de tipo coso"
                 )
             )
 
         if not isinstance(index, Numero):
             return RTResult().failure(
-                RTError(
-                    self.pos_start,
-                    self.pos_end,
-                    "El segundo argumento debe ser de tipo número.",
-                    exec_ctx,
+                InvalidTypeBardo(
+                    index.pos_start,
+                    index.pos_end,
+                    "El argumento debe ser de tipo numero"
                 )
             )
 
@@ -415,11 +421,10 @@ class Curro(BaseLaburo):
             list_.elements.insert(index.value, value.value)
         except TypeError:
             return RTResult().failure(
-                RTError(
-                    self.pos_start,
-                    self.pos_end,
-                    "El índice debe ser un número entero.",
-                    exec_ctx,
+                InvalidTypeBardo(
+                    index.pos_start,
+                    index.pos_end,
+                    "El argumento debe ser un entero."
                 )
             )
 
@@ -429,6 +434,7 @@ class Curro(BaseLaburo):
 
     def exec_cambiaso(self, exec_ctx):
         from . import Coso, Numero, Nada
+        from errors import InvalidIndexBardo, InvalidTypeBardo
 
         list_ = exec_ctx.symbol_table.get("list")
         index = exec_ctx.symbol_table.get("index")
@@ -436,21 +442,19 @@ class Curro(BaseLaburo):
 
         if not isinstance(list_, Coso):
             return RTResult().failure(
-                RTError(
-                    self.pos_start,
-                    self.pos_end,
-                    "El primer argumento debe ser de tipo coso.",
-                    exec_ctx,
+                InvalidTypeBardo(
+                    list_.pos_start,
+                    list_.pos_end,
+                    "El argumento debe ser de tipo coso"
                 )
             )
 
         if not isinstance(index, Numero):
             return RTResult().failure(
-                RTError(
-                    self.pos_start,
-                    self.pos_end,
-                    "El segundo argumento debe ser de tipo número.",
-                    exec_ctx,
+                InvalidTypeBardo(
+                    index.pos_start,
+                    index.pos_end,
+                    "El argumento debe ser de tipo numero"
                 )
             )
 
@@ -458,11 +462,18 @@ class Curro(BaseLaburo):
             list_.elements[index.value] = value.value
         except TypeError:
             return RTResult().failure(
-                RTError(
-                    self.pos_start,
-                    self.pos_end,
-                    "El índice debe ser un número entero.",
-                    exec_ctx,
+                InvalidTypeBardo(
+                    index.pos_start,
+                    index.pos_end,
+                    "El argumento debe ser un entero."
+                )
+            )
+        except IndexError:
+            return RTResult().failure(
+                InvalidIndexBardo(
+                    index.pos_start,
+                    index.pos_end,
+                    f"Elemento con el índice '{index.value}' no pudo ser reemplazado del coso porque el índice está fuera de los límites."
                 )
             )
 
@@ -472,27 +483,26 @@ class Curro(BaseLaburo):
 
     def exec_sacar(self, exec_ctx):
         from . import Numero, Coso
+        from errors import InvalidIndexBardo, InvalidTypeBardo
 
         list_ = exec_ctx.symbol_table.get("list")
         index = exec_ctx.symbol_table.get("index")
 
         if not isinstance(list_, Coso):
             return RTResult().failure(
-                RTError(
-                    self.pos_start,
-                    self.pos_end,
-                    "El primer argumento debe ser de tipo coso.",
-                    exec_ctx,
+                InvalidTypeBardo(
+                    list_.pos_start,
+                    list_.pos_end,
+                    "El argumento debe ser de tipo coso."
                 )
             )
 
         if not isinstance(index, Numero):
             return RTResult().failure(
-                RTError(
-                    self.pos_start,
-                    self.pos_end,
-                    "El segundo argumento debe ser de tipo número.",
-                    exec_ctx,
+                InvalidTypeBardo(
+                    index.pos_start,
+                    index.pos_end,
+                    "El argumento debe ser de tipo numero."
                 )
             )
 
@@ -500,11 +510,10 @@ class Curro(BaseLaburo):
             popped = list_.elements.pop(index.value)
         except IndexError:
             return RTResult().failure(
-                RTError(
+                InvalidIndexBardo(
                     self.pos_start,
                     self.pos_end,
-                    f"Elemento con el índice {index.value} no pudo ser removido del coso porque el índice está fuera de los límites.",
-                    exec_ctx,
+                    f"Elemento con el índice '{index.value}' no pudo ser removido del coso porque el índice está fuera de los límites."
                 )
             )
 
@@ -514,27 +523,26 @@ class Curro(BaseLaburo):
 
     def exec_extender(self, exec_ctx):
         from . import Nada, Coso
+        from errors import InvalidTypeBardo
 
         listA = exec_ctx.symbol_table.get("listA")
         listB = exec_ctx.symbol_table.get("listB")
 
         if not isinstance(listA, Coso):
             return RTResult().failure(
-                RTError(
-                    self.pos_start,
-                    self.pos_end,
-                    "El primer argumento debe ser de tipo coso.",
-                    exec_ctx,
+                InvalidTypeBardo(
+                    listA.pos_start,
+                    listA.pos_end,
+                    "El argumento debe ser de tipo coso."
                 )
             )
 
         if not isinstance(listB, Coso):
             return RTResult().failure(
-                RTError(
-                    self.pos_start,
-                    self.pos_end,
-                    "El segundo argumento debe ser de tipo coso.",
-                    exec_ctx,
+                InvalidTypeBardo(
+                    listB.pos_start,
+                    listB.pos_end,
+                    "El argumento debe ser de tipo coso."
                 )
             )
 
@@ -546,27 +554,26 @@ class Curro(BaseLaburo):
 
     def exec_agarra_de(self, exec_ctx):
         from . import Chamuyo, Numero, Mataburros, Nada
+        from errors import InvalidTypeBardo
 
         dict_ = exec_ctx.symbol_table.get("dict")
         key = exec_ctx.symbol_table.get("key")
 
         if not isinstance(dict_, Mataburros):
             return RTResult().failure(
-                RTError(
-                    self.pos_start,
-                    self.pos_end,
-                    "El primer argumento debe ser de tipo mataburros.",
-                    exec_ctx,
+                InvalidTypeBardo(
+                    dict_.pos_start,
+                    dict_.pos_end,
+                    "El argumento debe ser de tipo mataburros"
                 )
             )
 
         if not isinstance(key, (Numero, Chamuyo)):
             return RTResult().failure(
-                RTError(
-                    self.pos_start,
-                    self.pos_end,
-                    "El segundo argumento debe ser de tipo número o chamuyo.",
-                    exec_ctx,
+                InvalidTypeBardo(
+                    key.pos_start,
+                    key.pos_end,
+                    "El argumento debe ser de tipo numero o chamuyo."
                 )
             )
 
@@ -580,6 +587,7 @@ class Curro(BaseLaburo):
 
     def exec_metele_en(self, exec_ctx):
         from . import Chamuyo, Numero, Mataburros, Nada
+        from errors import InvalidTypeBardo
 
         dict_ = exec_ctx.symbol_table.get("dict")
         key = exec_ctx.symbol_table.get("key")
@@ -587,21 +595,19 @@ class Curro(BaseLaburo):
 
         if not isinstance(dict_, Mataburros):
             return RTResult().failure(
-                RTError(
-                    self.pos_start,
-                    self.pos_end,
-                    "El primer argumento debe ser de tipo mataburros.",
-                    exec_ctx,
+                InvalidTypeBardo(
+                    dict_.pos_start,
+                    dict_.pos_end,
+                    "El argumento debe ser de tipo mataburros"
                 )
             )
 
         if not isinstance(key, (Numero, Chamuyo)):
             return RTResult().failure(
-                RTError(
-                    self.pos_start,
-                    self.pos_end,
-                    "El segundo argumento debe ser de tipo número o chamuyo.",
-                    exec_ctx,
+                InvalidTypeBardo(
+                    key.pos_start,
+                    key.pos_end,
+                    "El argumento debe ser de tipo numero o chamuyo."
                 )
             )
 
@@ -612,27 +618,26 @@ class Curro(BaseLaburo):
 
     def exec_borra_de(self, exec_ctx):
         from . import Chamuyo, Numero, Mataburros, Nada
+        from errors import InvalidTypeBardo, InvalidKeyBardo
 
         dict_ = exec_ctx.symbol_table.get("dict")
         key = exec_ctx.symbol_table.get("key")
 
         if not isinstance(dict_, Mataburros):
             return RTResult().failure(
-                RTError(
-                    self.pos_start,
-                    self.pos_end,
-                    "El primer argumento debe ser de tipo mataburros.",
-                    exec_ctx,
+                InvalidTypeBardo(
+                    dict_.pos_start,
+                    dict_.pos_end,
+                    "El argumento debe ser de tipo mataburros"
                 )
             )
 
         if not isinstance(key, (Numero, Chamuyo)):
             return RTResult().failure(
-                RTError(
-                    self.pos_start,
-                    self.pos_end,
-                    "El segundo argumento debe ser de tipo número o chamuyo.",
-                    exec_ctx,
+                InvalidTypeBardo(
+                    key.pos_start,
+                    key.pos_end,
+                    "El argumento debe ser de tipo numero o chamuyo."
                 )
             )
 
@@ -641,39 +646,37 @@ class Curro(BaseLaburo):
             return RTResult().success(Nada.nada)
         
         return RTResult().failure(
-            RTError(
-                self.pos_start,
-                self.pos_end,
-                f"El elemento con la clave {key} no pudo ser encontrado en el mataburros.",
-                exec_ctx,
+            InvalidKeyBardo(
+                key.pos_start,
+                key.pos_end,
+                f"El elemento con la clave {key} no pudo ser encontrado en el mataburros."
             )
         )
 
     exec_borra_de.arg_names = ["dict", "key"]
 
     def exec_existe_clave(self, exec_ctx):
-        from . import Chamuyo, Numero, Mataburros, Laburo, Curro, Nada, Boloodean
+        from . import Chamuyo, Numero, Mataburros, Nada, Boloodean
+        from errors import InvalidTypeBardo
 
         dict_ = exec_ctx.symbol_table.get("dict")
         key = exec_ctx.symbol_table.get("key")
 
         if not isinstance(dict_, Mataburros):
             return RTResult().failure(
-                RTError(
-                    self.pos_start,
-                    self.pos_end,
-                    "El primer argumento debe ser de tipo mataburros.",
-                    exec_ctx,
+                InvalidTypeBardo(
+                    dict_.pos_start,
+                    dict_.pos_end,
+                    "El argumento debe ser de tipo mataburros"
                 )
             )
 
-        if not isinstance(key, (Numero, Chamuyo, Laburo, Curro)):
+        if not isinstance(key, (Numero, Chamuyo, Nada, Boloodean)):
             return RTResult().failure(
-                RTError(
-                    self.pos_start,
-                    self.pos_end,
-                    "El segundo argumento no puede ser de tipo Coso ó Mataburros.",
-                    exec_ctx,
+                InvalidTypeBardo(
+                    key.pos_start,
+                    key.pos_end,
+                    "El argumento debe ser de tipo numero, chamuyo, nada o boloodean"
                 )
             )
 
@@ -686,16 +689,16 @@ class Curro(BaseLaburo):
 
     def exec_longitud(self, exec_ctx):
         from . import Numero, Coso, Mataburros, Chamuyo, Nada
+        from errors import InvalidTypeBardo
 
         arg = exec_ctx.symbol_table.get("arg")
 
         if not isinstance(arg, (Coso, Mataburros, Chamuyo)):
             return RTResult().failure(
-                RTError(
-                    self.pos_start,
-                    self.pos_end,
-                    "El argumento debe ser de tipo coso, mataburros o chamuyo.",
-                    exec_ctx,
+                InvalidTypeBardo(
+                    arg.pos_start,
+                    arg.pos_end,
+                    "El argumento debe ser de tipo coso, chamuyo o mataburros"
                 )
             )
 
@@ -714,16 +717,16 @@ class Curro(BaseLaburo):
 
     def exec_ejecutar(self, exec_ctx):
         from . import Chamuyo, Nada
+        from errors import InvalidTypeBardo
 
         fn = exec_ctx.symbol_table.get("fn")
 
         if not isinstance(fn, Chamuyo):
             return RTResult().failure(
-                RTError(
-                    self.pos_start,
-                    self.pos_end,
-                    "El primer argumento debe ser de tipo chamuyo.",
-                    exec_ctx,
+                InvalidTypeBardo(
+                    fn.pos_start,
+                    fn.pos_end,
+                    "El argumento debe ser de tipo chamuyo"
                 )
             )
 
@@ -774,7 +777,7 @@ class Curro(BaseLaburo):
     exec_renuncio.arg_names = []
 
     def exec_contexto_global(self, exec_ctx):
-        from . import Mataburros, Boloodean, Chamuyo
+        from . import Mataburros, Boloodean
 
         _local = exec_ctx.symbol_table.get("local")
         if isinstance(_local, Boloodean):
@@ -792,19 +795,21 @@ class Curro(BaseLaburo):
 
     def exec_asciiAchamu(self, exec_ctx):
         from . import Chamuyo, Numero
+        from errors import InvalidTypeBardo
 
         code = exec_ctx.symbol_table.get("ascii_code")
         if not isinstance(code, Numero):
             return RTResult().failure(
-                RTError(
-                    self.pos_start,
-                    self.pos_end,
-                    "El argumento debe ser de tipo número.",
-                    exec_ctx,
+                InvalidTypeBardo(
+                    code.pos_start,
+                    code.pos_end,
+                    "El argumento debe ser de tipo numero"
                 )
             )
+        
+        code = int(code.value)
 
-        return RTResult().success(Chamuyo(chr(code.value)))
+        return RTResult().success(Chamuyo(chr(code)))
     
     exec_asciiAchamu.arg_names = ['ascii_code']
 

--- a/src/nodes.py
+++ b/src/nodes.py
@@ -481,3 +481,26 @@ class ImportarNode:
     
     def __str__(self) -> str:
         return f'ImportarNode({self.module_name_node})'
+    
+class ProbaSiBardeaNode:
+    """ Represents a try-except code block in the AST """
+
+    def __init__(self, try_body_node, bardo_name, except_body_node) -> None:
+        """
+        Initialize a ProbaSiBardeaNode.
+
+        Args:
+            try_body (Node): Node representing the node to try
+            except_body (Node): Node representing the node to execute in case of Bardo (exception)
+        """
+        self.try_body_node = try_body_node
+        self.except_body_node = except_body_node
+        self.bardo_name = bardo_name
+        self.pos_start = self.try_body_node.pos_start
+        self.pos_end = self.except_body_node.pos_end
+
+    def __repr__(self) -> str:
+        return f'ProbaSiBardeaNode({self.try_body_node}, {self.except_body_node})'
+    
+    def __str__(self) -> str:
+        return f'ProbaSiBardeaNode({self.try_body_node}, {self.except_body_node})'


### PR DESCRIPTION
## Features
- proba-sibardea code block (equivalent to try-except block). Currently limited to one except block.
- updated errors, now named "bardos".

## Chore
- updated a single comment in keywords.py for clarity.
- updated lacompu.py to fit mataburros new implementation.

## Bugfix
- errors (now bardos) won't propagate at the end of a codeblock: now it should propagate every error, although it will still be monitored.