### PR TITLE
Release/bardea expression

### DIFF
--- a/src/constants/keywords.py
+++ b/src/constants/keywords.py
@@ -1,5 +1,5 @@
 KEYWORDS = [
-    'poneleque', # variable
+    'poneleque', # variable declaration
     'y', # and
     'o', # or
     'truchar', # not
@@ -21,4 +21,5 @@ KEYWORDS = [
     'importar', # import
     'proba', # try
     'sibardea', # except / catch
+    'bardea', # raise / throw
 ]

--- a/src/constants/tokens.py
+++ b/src/constants/tokens.py
@@ -24,5 +24,6 @@ TT_GTE          = 'GTE' # >=
 TT_COMMA        = 'COMMA'
 TT_COLON        = 'COLON'
 TT_DOT          = 'DOT'
+TT_ARROW        = 'ARROW' # ->
 TT_NEWLINE      = 'NEWLINE'
 TT_EOF          = 'EOF'

--- a/src/examples/bardos.lunf
+++ b/src/examples/bardos.lunf
@@ -1,0 +1,17 @@
+laburo retornar_bardo(valor)
+    si valor == 1 entonces
+        bardea bardo_de_valor -> "A este laburo no se le puede pasar un valor de '1', cuchaste?"
+    sino
+        matear(valor)
+    chau
+chau
+
+
+poneleque v = 1
+#retornar_bardo(v) sacar este comentario para que el mensaje de bardo de retornar_bardo() se muestre
+
+proba:
+    retornar_bardo("holis")
+    retornar_bardo(v)
+sibardea bardo_de_valor:
+    matear("Hubo un bardo de valor: " + chamu(v))

--- a/src/interpreter.py
+++ b/src/interpreter.py
@@ -1034,6 +1034,43 @@ class Interpreter:
             return res
         
         return res.success(try_value)
+    
+    def visit_BardeaNode(self, node: BardeaNode, context: Context) -> RTResult:
+        res = RTResult()
+        from errors import (
+            IllegalCharBardo,
+            InvalidSyntaxBardo,
+            ExpectedCharBardo,
+            InvalidTypeBardo,
+            InvalidIndexBardo,
+            InvalidKeyBardo,
+            InvalidValueBardo
+        )
+
+        AVAILABLE_BARDOS = {
+            'caracter_ilegal': IllegalCharBardo,
+            'sintaxis_invalida': InvalidSyntaxBardo,
+            'caracter_esperado': ExpectedCharBardo,
+            'bardo_de_tipo': InvalidTypeBardo,
+            'bardo_de_indice': InvalidIndexBardo,
+            'bardo_de_clave': InvalidKeyBardo,
+            'bardo_de_valor': InvalidValueBardo
+        }
+        
+        bardo_msg = res.register(self.visit(node.bardo_msg_node, context))
+        if res.should_return():
+            return res
+        
+        bardo_name = node.bardo_name_tok.value
+        return res.failure(
+            AVAILABLE_BARDOS[bardo_name](
+                node.pos_start,
+                node.pos_end,
+                f"{bardo_msg.value}"
+            )
+        )
+        
+
 
     @staticmethod
     def handle_library_import(lib_name: str, node: ImportarNode, module_context: Context, context: Context) -> RTResult:

--- a/src/lexer.py
+++ b/src/lexer.py
@@ -79,8 +79,7 @@ class Lexer:
                 self.advance()
             
             elif self.current_char == '-':
-                tokens.append(Token(TT_MINUS, pos_start = self.pos))
-                self.advance()
+                tokens.append(self.make_minus_or_arrow())
             
             elif self.current_char == '*':
                 tokens.append(Token(TT_MUL, pos_start = self.pos))
@@ -311,6 +310,24 @@ class Lexer:
             tok_type = TT_GTE
 
         return Token(tok_type, pos_start = pos_start, pos_end = self.pos)
+    
+    def make_minus_or_arrow(self) -> Token:
+        """
+        Parse and create a minus or arrow token.
+
+        Returns:
+            Token: A MINUS or ARROW token
+        """
+        tok_type = TT_MINUS
+        pos_start = self.pos.copy()
+        self.advance()
+
+        if self.current_char == '>':
+            self.advance()
+            tok_type = TT_ARROW
+
+        return Token(tok_type, pos_start = pos_start, pos_end = self.pos)
+
     
     def skip_comment(self) -> None:
         self.advance()

--- a/src/nodes.py
+++ b/src/nodes.py
@@ -490,8 +490,9 @@ class ProbaSiBardeaNode:
         Initialize a ProbaSiBardeaNode.
 
         Args:
-            try_body (Node): Node representing the node to try
-            except_body (Node): Node representing the node to execute in case of Bardo (exception)
+            try_body_node (Node): Node representing the node to try
+            bardo_name (str): str representing the bardo name (should be a node actually, but will be implemented later on)
+            except_body_node (Node): Node representing the node to execute in case of Bardo (exception)
         """
         self.try_body_node = try_body_node
         self.except_body_node = except_body_node
@@ -504,3 +505,25 @@ class ProbaSiBardeaNode:
     
     def __str__(self) -> str:
         return f'ProbaSiBardeaNode({self.try_body_node}, {self.except_body_node})'
+
+class BardeaNode:
+    """ Represents a raise code expression in the AST """
+
+    def __init__(self, bardo_name_tok, bardo_msg_node) -> None:
+        """
+        Initialize a BardeaNode.
+
+        Args:
+            bardo_name_tok (Token): Token representing the bardo name (should be a node actually, but will be implemented later on)
+            bardo_msg_node (Node): Node representing the message to pass to the bardo.
+        """
+        self.bardo_name_tok = bardo_name_tok
+        self.bardo_msg_node = bardo_msg_node
+        self.pos_start = self.bardo_name_tok.pos_start
+        self.pos_end = self.bardo_msg_node.pos_end
+
+    def __repr__(self) -> str:
+        return f'BardeaNode({self.bardo_name_tok}, {self.bardo_msg_node})'
+    
+    def __str__(self) -> str:
+        return f'BardeaNode({self.bardo_name_tok}, {self.bardo_msg_node})'


### PR DESCRIPTION
## Features
- `bardea` expression, equivalent to `raise` or `throw` in other programming languages.
- New token: Arrow `->`. It is used within a `bardea` expression.

## Chores
- Updated `src/constants/keywords.py` with the new keyword `bardea`
- Creation and update of `src/examples/bardos.lunf`