### PR TITLE
Feature/run from anywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,16 +28,22 @@ git clone https://github.com/WhiteHeadbanger/Lunfardo.git
 ### Ejecución
 
 ```sh
-cd src
-python3 run.py
+python3 src/run.py
 ```
 
 Esto iniciará el intérprete interactivo de Lunfardo.
 
 ### Ejecutar un archivo
 
-`ejecutar("nombre_del_archivo.lunf")`
-Por defecto, los archivos deben estar dentro de la carpeta `src/examples`. Esto está sujeto a cambios a medida que evolucione.
+```sh
+python3 src/run.py <ruta_del_archivo.lunf>
+```
+
+#### Ejemplo
+
+```sh
+python3 src/run.py src/examples/banco_oop.lunf
+```
 
 ## Características
 

--- a/src/context.py
+++ b/src/context.py
@@ -5,6 +5,8 @@ This module defines the Context class, which represents the execution context
 for Lunfardo code, including scope and symbol table information.
 """
 
+from typing import Dict, Optional
+
 class Context:
     """
     Represents an execution context in the Lunfardo language.
@@ -12,8 +14,8 @@ class Context:
     The Context class maintains information about the current scope,
     including its parent context and symbol table.
     """
-
-    def __init__(self, display_name, parent = None, parent_entry_pos = None) -> None:
+    
+    def __init__(self, display_name, parent = None, parent_entry_pos = None, cwd = None, file = None) -> None:
         """
         Initialize a Context object.
 
@@ -25,4 +27,46 @@ class Context:
         self.display_name = display_name
         self.parent = parent
         self.parent_entry_pos = parent_entry_pos
+        self.cwd = cwd
+        self.file = file
         self.symbol_table = None
+        self.modules = {}
+
+    def get_cwd(self):
+        """
+        Retrieve the current working directory for this context.
+        """
+        cwd = self.cwd
+        if cwd is None and self.parent:
+            cwd = self.parent.get_cwd()
+        return cwd
+
+    def get_file(self) -> str | None:
+        """
+        Retrieve the current file for this context.
+        """
+        file = self.file
+        if file is None and self.parent:
+            file = self.parent.get_file()
+        return file
+    
+    def get_parent(self) -> Optional["Context"]:
+        """
+        Retrieve the parent context for this context.
+        """
+        return self.parent
+    
+    def add_module(self, module: Dict) -> None:
+        """
+        Add a module to this context.
+        """
+        self.modules.update(module)
+
+    def get_module(self, module_name: str):
+        """
+        Retrieve a module from this context.
+        """
+        for i, (_, v) in enumerate(self.modules.items()):
+            if v.elements[i].name == module_name:
+                return v.elements[i]
+        return self.modules.get(module_name)

--- a/src/context_typed.py
+++ b/src/context_typed.py
@@ -1,0 +1,188 @@
+"""
+Context module for the Lunfardo programming language.
+
+This module defines the Context class, which represents the execution context
+for Lunfardo code, including scope and symbol table information.
+"""
+
+from typing import Optional
+
+class Context:
+    """
+    Represents an execution context in the Lunfardo language.
+
+    The Context class maintains information about the current scope,
+    including its parent context and symbol table.
+    """
+
+    from lunfardo_token import Position
+
+    def __init__(self, display_name: str, parent: Optional["Context"] = None, parent_entry_pos: Optional[Position] = None, cwd: str | None = None, file: str | None = None) -> None:
+        """
+        Initialize a Context object.
+
+        Args:
+            display_name (str): A name for this context, used for display purposes.
+            parent (Context, optional): The parent context, if any.
+            parent_entry_pos (Position, optional): The position where this context was entered in the parent context.
+            cwd (str, optional): The current working directory for this context.
+            file (str, optional): The filename associated with this context.
+        """
+        self._display_name = display_name
+        self._parent = parent
+        self._parent_entry_pos = parent_entry_pos
+        self._cwd = cwd
+        self._file = file
+        self._symbol_table = None
+
+    @property
+    def display_name(self) -> str:
+        """
+        Get the display name for this context.
+
+        Returns:
+            str: The display name.
+        """
+        return self._display_name
+    
+    @property
+    def parent(self) -> Optional["Context"]:
+        """
+        Get the parent context for this context.
+
+        Returns:
+            Context: The parent context.
+        """
+        return self._parent
+    
+    @property
+    def parent_entry_pos(self) -> Optional["Position"]:
+        """
+        Get the position where this context was entered in the parent context.
+
+        Returns:
+            Position: The position where this context was entered.
+        """
+        return self._parent_entry_pos
+    
+    @property
+    def cwd(self) -> str | None:
+        """
+        Get the current working directory for this context.
+
+        Returns:
+            str: The current working directory.
+        """
+
+        return self._cwd
+    
+    @property
+    def file(self) -> str | None:
+        """
+        Get the filename associated with this context.
+
+        Returns:
+            str: The filename.
+        """
+        return self._file
+    
+    @property
+    def symbol_table(self):
+        """
+        Get the symbol table for this context.
+
+        Returns:
+            SymbolTable: The symbol table.
+        """
+        return self._symbol_table
+    
+    @display_name.setter
+    def display_name(self, value: str) -> None:
+        """
+        Set the display name for this context.
+
+        Args:
+            value (str): The new display name.
+        """
+        if value is None:
+            value = ""
+        
+        if not isinstance(value, str):
+            raise TypeError("Context display name must be a string.")
+        
+        self._display_name = value
+
+    @parent.setter
+    def parent(self, value: "Context") -> None:
+        """
+        Set the parent context for this context.
+
+        Args:
+            value (Context): The new parent context.
+        """
+        if not isinstance(value, Context):
+            raise TypeError("Context parent must be a Context object.")
+        
+        self._parent = value
+
+    @parent_entry_pos.setter
+    def parent_entry_pos(self, value) -> None:
+        """
+        Set the position where this context was entered in the parent context.
+
+        Args:
+            value (Position): The new entry position.
+        """
+        from lunfardo_token import Position
+
+        if not isinstance(value, Position):
+            raise TypeError("Context parent entry position must be a Position object.")
+        
+        self._parent_entry_pos = value
+
+    @cwd.setter
+    def cwd(self, value: str) -> None:
+        """
+        Set the current working directory for this context.
+
+        Args:
+            value (str): The new working directory.
+        """
+        if value is None:
+            value = ""
+
+        if not isinstance(value, str):
+            raise TypeError("Context working directory must be a string.")
+        
+        self._cwd = value
+
+    @file.setter
+    def file(self, value: str) -> None:
+        """
+        Set the filename associated with this context.
+
+        Args:
+            value (str): The new filename.
+        """
+        if value is None:
+            value = ""
+
+        if not isinstance(value, str):
+            raise TypeError("Context filename must be a string.")
+        
+        self._file = value
+
+    @symbol_table.setter
+    def symbol_table(self, value) -> None:
+        """
+        Set the symbol table for this context.
+
+        Args:
+            value (SymbolTable): The new symbol table.
+        """
+        from symbol_table import SymbolTable
+        
+        if not isinstance(value, SymbolTable):
+            raise TypeError("Context symbol table must be a SymbolTable object.")
+        
+        self._symbol_table = value

--- a/src/errors/errors.py
+++ b/src/errors/errors.py
@@ -82,7 +82,7 @@ class RTError(Bardo):
         
 
         while ctx:
-            result = f' {self.default_color}Fichero {self.accent_color}{pos.fn}{self.default_color}, línea {self.accent_color}{str(pos.ln + 1)}{self.default_color}, en {self.accent_color}{ctx.display_name}\n{result}'
+            result = f' {self.default_color}Fichero {self.accent_color}{pos.fn}{self.default_color}, línea {self.accent_color}{str(pos.ln + 1)}{self.default_color}, en {self.accent_color}{ctx.display_name if isinstance(ctx.display_name, str) else "<modulo>"}\n{result}'
             pos = ctx.parent_entry_pos
             ctx = ctx.parent
 

--- a/src/examples/gualichos_calculadora.lunf
+++ b/src/examples/gualichos_calculadora.lunf
@@ -1,4 +1,4 @@
-importar "gualichos.lunf"
+importar gualichos
 
 poneleque menu_opciones = ["Sumar", "Restar", "Multiplicar", "Dividir", "Salir"]
 

--- a/src/examples/lacompu_ejemplo.lunf
+++ b/src/examples/lacompu_ejemplo.lunf
@@ -1,4 +1,4 @@
-importar "lacompu.lunf"
+importar lacompu
 
 matear("Dir actual: " + obtener_dir_actual())
 matear("Listado de directorio: ")

--- a/src/examples/perro.lunf
+++ b/src/examples/perro.lunf
@@ -1,4 +1,4 @@
-importar "animal.lunf"
+importar animal
 
 cheto Perro(Animal)
     laburo ladrar(mi, cantidad)

--- a/src/interpreter.py
+++ b/src/interpreter.py
@@ -99,6 +99,12 @@ class Interpreter:
         var_name = node.var_name_tok.value
         value = context.symbol_table.get(var_name)
 
+        if not value and context.modules:
+            for module in context.modules.values():
+                value = module.context.symbol_table.get(var_name)
+                if value:
+                    break
+                
         if not value:
             return res.failure(RTError(
                 node.pos_start, 
@@ -106,7 +112,6 @@ class Interpreter:
                 f"'{var_name}' no esta definido",
                 context
             ))
-        
         #value = value.copy().set_pos(node.pos_start, node.pos_end).set_context(context)
         value = value.set_pos(node.pos_start, node.pos_end).set_context(context)
         return res.success(value)

--- a/src/interpreter.py
+++ b/src/interpreter.py
@@ -1,3 +1,4 @@
+import os
 from rtresult import RTResult
 from constants.tokens import *
 from lunfardo_types import Numero, Nada
@@ -1044,8 +1045,14 @@ class Interpreter:
 
         if module_name.replace(".lunf", "") in BUILTINS:
 
-            file_name = f"builtin/{module_name}" #prod
+            #file_name = f"builtin/{module_name}" #prod
             #file_name = f"src/builtin/{module_name}" #test (debugger)
+
+            file_name = context.cwd
+            while file_name.name != 'src':
+                file_name = file_name.parent
+            
+            file_name = os.path.join(file_name, "builtin", module_name)
 
             try:
                 with open(file_name, "r", encoding="utf-8") as f:
@@ -1100,7 +1107,9 @@ class Interpreter:
             
             context.add_module({module_name: import_value})
         
-        return res.success(import_value)
+            return res.success(import_value)
+        
+        return res.success(Nada.nada)
     
     def visit_ProbaSiBardeaNode(self, node: ProbaSiBardeaNode, context: Context) -> RTResult:
         res = RTResult()

--- a/src/interpreter.py
+++ b/src/interpreter.py
@@ -1061,7 +1061,7 @@ class Interpreter:
         res = RTResult()
         
         try: 
-            module_name = node.module_name_node.var_name_tok.value
+            module_name = node.module_node.var_name_tok.value
         except AttributeError: 
             return res.failure(RTError(
                 node.pos_start,
@@ -1072,7 +1072,7 @@ class Interpreter:
         
         ejecutar_func = context.symbol_table.get("ejecutar").set_pos(node.pos_start, node.pos_end)
         
-        module = res.register(self.visit_ChamuyoNode(ChamuyoNode(node.module_name_node.var_name_tok), context))
+        module = res.register(self.visit_ChamuyoNode(ChamuyoNode(node.module_node.var_name_tok), context))
         if res.should_return():
             return res
         

--- a/src/lunfardo_parser.py
+++ b/src/lunfardo_parser.py
@@ -1840,12 +1840,12 @@ class Parser:
         res.register_advance()
         self.advance()
 
-        if self.current_tok.type != TT_STRING:
+        if self.current_tok.type != TT_IDENTIFIER:
             return res.failure(
                 InvalidSyntaxBardo(
                     self.current_tok.pos_start,
                     self.current_tok.pos_end,
-                    "El nombre del modulo a importar debe ser un chamuyo",
+                    "El nombre del modulo a importar debe ser un identificador",
                 )
             )
 

--- a/src/lunfardo_types/cheto.py
+++ b/src/lunfardo_types/cheto.py
@@ -13,7 +13,7 @@ class Cheto(Value):
         self.methods: dict = methods
         self.parent_context = parent_context
         self.parent_class = parent_class
-        self.context = Context(f"<cheto {self.name}>", parent_context)
+        self.context = Context(f"<cheto {self.name}>", parent=parent_context)
         self.context.symbol_table = SymbolTable(parent_context.symbol_table if parent_context else None)
 
     def create_instance(self, args, call_context):
@@ -62,7 +62,7 @@ class Cheto(Value):
             ))
         
         # Create a new execution context for the method call
-        method_context = Context(f"<método {method_name}>", call_context)
+        method_context = Context(f"<método {method_name}>", parent=call_context)
         #method_context.symbol_table = SymbolTable(call_context.symbol_table)
         method_context.symbol_table = SymbolTable(instance.context.symbol_table)
 
@@ -108,7 +108,7 @@ class ChetoInstance(Value):
         self.cheto = cheto
         self.name = cheto.name
         self.instance_vars = {}
-        self.context = Context(f"<instancia de {cheto.name}>", call_context)
+        self.context = Context(f"<instancia de {cheto.name}>", parent=call_context)
         self.context.symbol_table = SymbolTable(call_context.symbol_table)
         self.set_pos(cheto.pos_start, cheto.pos_end)
 

--- a/src/nodes.py
+++ b/src/nodes.py
@@ -487,22 +487,22 @@ class RajarNode:
 class ImportarNode:
     """Represents an import statement in the AST."""
 
-    def __init__(self, module_name_node: ChamuyoNode) -> None:
+    def __init__(self, module_node: PoneleQueAccessNode) -> None:
         """
         Initialize an ImportarNode.
 
         Args:
             module_name_node (ChamuyoNode): Node representing the module name.
         """
-        self.module_name_node = module_name_node
-        self.pos_start = self.module_name_node.pos_start
-        self.pos_end = self.module_name_node.pos_end
+        self.module_node = module_node
+        self.pos_start = self.module_node.pos_start
+        self.pos_end = self.module_node.pos_end
 
     def __repr__(self) -> str:
-        return f'ImportarNode({self.module_name_node})'
+        return f'ImportarNode({self.module_node})'
     
     def __str__(self) -> str:
-        return f'ImportarNode({self.module_name_node})'
+        return f'ImportarNode({self.module_node})'
     
 class ProbaSiBardeaNode:
     """ Represents a try-except code block in the AST """

--- a/src/run.py
+++ b/src/run.py
@@ -11,7 +11,8 @@ from pathlib import Path
 from lexer import Lexer
 from lunfardo_parser import Parser
 from lunfardo_types import Curro, Boloodean, Nada
-from interpreter import Interpreter, SymbolTable
+from interpreter import Interpreter
+from symbol_table import SymbolTable
 from context import Context
 from typing import Tuple
 

--- a/src/run.py
+++ b/src/run.py
@@ -4,7 +4,7 @@ Main execution module for the Lunfardo programming language.
 This module contains the global symbol table setup, execution function,
 and the main REPL (Read-Eval-Print Loop) for the Lunfardo interpreter.
 """
-
+import argparse
 from lexer import Lexer
 from lunfardo_parser import Parser
 from lunfardo_types import Curro, Boloodean, Nada
@@ -112,4 +112,28 @@ def run() -> None:
 
 
 if __name__ == "__main__":
-    run()
+    # Argument parsing
+    parser = argparse.ArgumentParser(description="Ejecutá código Lunfardo desde un archivo o iniciá el REPL.")
+    parser.add_argument("file", nargs="?", help="Ruta del archivo Lunfardo a ejecutar.")
+    args = parser.parse_args()
+
+    if args.file:
+        try:
+            with open(args.file, "r", encoding="utf-8") as f:
+                code = f.read()
+            result, error = execute(args.file, code)
+
+            if error:
+                print(error.as_string())
+            elif result:
+                if len(result.elements) == 1:
+                    print(repr(result.elements[0]))
+                else:
+                    print(repr(result))
+
+        except FileNotFoundError:
+            print(f"Error: File '{args.file}' not found.")
+        except Exception as e:
+            print(f"An error occurred: {e}")
+    else:
+        run()


### PR DESCRIPTION
## Features
- Lunfardo can now run from anywhere! Example: `python3 src/run.py src/ejemplos/banco_oop.lunf`
- Lunfardo import statements now accepts one identifier, instead of a `chamuyo`. Example: `importar gualichos`

## Chore
- Updated README.md to better reflect this change.