### PR TITLE
Feature/file io

### DIFF
--- a/src/builtin/archivos.lunf
+++ b/src/builtin/archivos.lunf
@@ -1,0 +1,70 @@
+laburo bardos(error)
+    si error == "archivo_no_encontrado" entonces
+        bardea archivo_no_encontrado -> ""
+    osi error == "bardo_de_permiso" entonces
+        bardea bardo_de_permiso -> ""
+    osi error == "es_un_directorio" entonces
+        bardea es_un_directorio -> ""
+    osi error == "bardo_de_valor" entonces
+        bardea bardo_de_valor -> ""
+    osi error == "bardo_de_tipo" entonces
+        bardea bardo_de_tipo -> ""
+    osi error == "bardo_unicode_decode" entonces
+        bardea bardo_unicode_decode -> ""
+    osi error == "bardo_unicode_enconde" entonces
+        bardea bardo_unicode_enconde -> ""
+    osi error == "bardo_de_io" entonces
+        bardea bardo_de_io -> ""
+    sino
+        bardea bardo_de_sistema -> ""
+    chau
+chau
+
+laburo abrir_archivo(ruta, modo = "r", codificacion = "utf-8")
+    poneleque retorno = open(ruta, modo, codificacion)
+    poneleque resultado = retorno / 0
+    poneleque error = retorno / 1
+
+    si error == nada entonces
+        devolver resultado
+    sino
+        bardos(error)
+    chau
+    
+chau
+
+laburo leer_archivo(archivo_id)
+    poneleque retorno = read(archivo_id)
+    poneleque resultado = retorno / 0
+    poneleque error = retorno / 1
+
+    si error == nada entonces
+        devolver resultado
+    sino
+        bardos(error)
+    chau
+chau
+
+laburo escribir_archivo(archivo_id, contenido)
+    poneleque retorno = write(archivo_id, contenido)
+    poneleque resultado = retorno / 0
+    poneleque error = retorno / 1
+
+    si error == nada entonces
+        devolver resultado
+    sino
+        bardos(error)
+    chau
+chau
+
+laburo cerrar_archivo(archivo_id)
+    poneleque retorno = close(archivo_id)
+    poneleque resultado = retorno / 0
+    poneleque error = retorno / 1
+
+    si error == nada entonces
+        devolver resultado
+    sino
+        bardos(error)
+    chau
+chau

--- a/src/builtin/lib/archivos.py
+++ b/src/builtin/lib/archivos.py
@@ -118,7 +118,7 @@ class Archivo:
             result = self.current_id - 1
             return result, None
         except Exception as e:
-            return None, handle_error(e)
+            return result, handle_error(e)
 
     def read(self, file_id: int) -> tuple[str | None, Error | None]:
         """

--- a/src/builtin/lib/archivos.py
+++ b/src/builtin/lib/archivos.py
@@ -88,6 +88,26 @@ class Archivo:
         self.open_files: dict[int, IO[Any]] = {}
         self.current_id: int = 0
 
+    def _get_file(self, file_id: int) -> tuple[IO[Any] | None, Error | None]:
+        """
+        Retrieve an open file handle from the internal registry.
+
+        Parameters
+        ----------
+        file_id
+            Identifier returned by `open()`.
+
+        Returns
+        -------
+        tuple
+            `(file, None)` if the file exists and is open,
+            `(None, Error.BARDO_DE_VALOR)` if the identifier is not valid.
+        """
+        file = self.open_files.get(file_id)
+        if file is None:
+            return None, Error.BARDO_DE_VALOR
+        return file, None
+
     def open(self, path: str, mode: str = 'r', encoding: str = 'utf-8') -> tuple[int | None, Error | None]:
         """
         Open a file and register it in the runtime file table.
@@ -137,13 +157,14 @@ class Archivo:
             `(content, None)` on success where `content` is a string containing the
             full file contents, or `(None, Error)` if the read operation fails.
         """
-        result = None
+        file, err = self._get_file(file_id)
+        if err:
+            return None, err
+
         try:
-            archivo = self.open_files[file_id]
-            result = archivo.read()
-            return result, None
+            return file.read(), None
         except Exception as e:
-            return result, handle_error(e)
+            return None, handle_error(e)
 
     def write(self, file_id: int, content: str) -> tuple[None, Error | None]:
         """
@@ -164,9 +185,12 @@ class Archivo:
         tuple
             `(None, None)` on success or `(None, Error)` if the write fails.
         """
+        file, err = self._get_file(file_id)
+        if err:
+            return None, err
+
         try:
-            archivo = self.open_files[file_id]
-            archivo.write(content)
+            file.write(content)
             return None, None
         except Exception as e:
             return None, handle_error(e)
@@ -188,9 +212,12 @@ class Archivo:
         tuple
             `(None, None)` on success or `(None, Error)` if closing fails.
         """
+        file, err = self._get_file(file_id)
+        if err:
+            return None, err
+
         try:
-            archivo = self.open_files[file_id]
-            archivo.close()
+            file.close()
             del self.open_files[file_id]
             return None, None
         except Exception as e:

--- a/src/builtin/lib/archivos.py
+++ b/src/builtin/lib/archivos.py
@@ -4,6 +4,14 @@ from typing import IO, Any
 from enum import Enum, auto
 
 class Error(Enum):
+    """
+    Enumeration of normalized file I/O errors exposed by the `archivos` runtime.
+
+    These values represent Lunfardo-level error categories produced when Python
+    file operations fail. The runtime maps Python exceptions to these values
+    through `handle_error()` so the language receives a stable and predictable
+    error set independent of the underlying OS.
+    """
     ARCHIVO_NO_ENCONTRADO = auto()
     BARDO_DE_PERMISO = auto()
     ES_UN_DIRECTORIO = auto()
@@ -15,6 +23,24 @@ class Error(Enum):
     BARDO_DE_SISTEMA = auto()
 
 def handle_error(error: Exception) -> Error:
+    """
+    Convert a Python exception raised during file I/O into a Lunfardo `Error`.
+
+    This function acts as a translation layer between Python's exception system
+    and Lunfardo's error model. Known exception types are mapped to specific
+    `Error` enum values. Any unrecognized exception falls back to
+    `Error.BARDO_DE_SISTEMA`.
+
+    Parameters
+    ----------
+    error
+        The Python exception raised during a file operation.
+
+    Returns
+    -------
+    Error
+        The corresponding Lunfardo error category.
+    """
     if isinstance(error, FileNotFoundError):
         return Error.ARCHIVO_NO_ENCONTRADO
     elif isinstance(error, PermissionError):
@@ -35,12 +61,55 @@ def handle_error(error: Exception) -> Error:
     return Error.BARDO_DE_SISTEMA
 
 class Archivo:
+    """
+    Facade responsible for managing open files in the Lunfardo runtime.
+
+    The class maintains an internal table of open file handles indexed by
+    numeric identifiers. These identifiers are returned to the language layer
+    and used for subsequent operations such as reading, writing, or closing
+    the file.
+
+    Each method returns a tuple `(result, error)` where only one value should
+    be non-null:
+        - On success: `(result, None)`
+        - On failure: `(None, Error)`
+
+    File handles remain valid until `close()` is called or the runtime ends.
+    Currently only text mode operations are supported.
+    """
 
     def __init__(self):
+        """
+        Initialize the file manager.
+
+        Creates an empty registry of open files and prepares the internal counter
+        used to assign unique identifiers to newly opened files.
+        """
         self.open_files: dict[int, IO[Any]] = {}
         self.current_id: int = 0
 
     def open(self, path: str, mode: str = 'r', encoding: str = 'utf-8') -> tuple[int | None, Error | None]:
+        """
+        Open a file and register it in the runtime file table.
+
+        A new numeric identifier is assigned to the opened file and returned to the
+        caller. This identifier must be used for subsequent read, write, or close
+        operations.
+
+        Parameters
+        ----------
+        path
+            Filesystem path to the file.
+        mode
+            File open mode (e.g. 'r', 'w', 'a').
+        encoding
+            Text encoding used when reading or writing.
+
+        Returns
+        -------
+        tuple
+            `(file_id, None)` on success or `(None, Error)` if the operation fails.
+        """
         result = None
         try:
             archivo = open(path, mode, encoding=encoding)
@@ -51,16 +120,50 @@ class Archivo:
         except Exception as e:
             return None, handle_error(e)
 
+        """
+        Read the entire contents of an open file.
+
+        The file must have been previously opened with `open()`.
+
     def read(self, file_id) -> tuple[str | None, Error | None]:
+        Parameters
+        ----------
+        file_id
+            Identifier of the open file.
+
+        Returns
+        -------
+        tuple
+            `(content, None)` on success where `content` is a string containing the
+            full file contents, or `(None, Error)` if the read operation fails.
+        """
         result = None
         try:
             archivo = self.open_files[file_id]
             result = archivo.read()
             return result, None
         except Exception as e:
-            return None, handle_error(e)
+            return result, handle_error(e)
+
+        """
+        Write text content to an open file.
+
+        The behavior depends on the mode used when opening the file
+        (e.g. overwrite or append).
 
     def write(self, file_id, content: str) -> tuple[None, Error | None]:
+        Parameters
+        ----------
+        file_id
+            Identifier of the open file.
+        content
+            Text content to write.
+
+        Returns
+        -------
+        tuple
+            `(None, None)` on success or `(None, Error)` if the write fails.
+        """
         try:
             archivo = self.open_files[file_id]
             archivo.write(content)
@@ -69,6 +172,22 @@ class Archivo:
             return None, handle_error(e)
 
     def close(self, file_id) -> tuple[None, Error | None]:
+        """
+        Close an open file and remove it from the runtime registry.
+
+        After this operation the file identifier becomes invalid and cannot be
+        reused for further operations.
+
+        Parameters
+        ----------
+        file_id
+            Identifier of the open file.
+
+        Returns
+        -------
+        tuple
+            `(None, None)` on success or `(None, Error)` if closing fails.
+        """
         try:
             archivo = self.open_files[file_id]
             archivo.close()
@@ -78,6 +197,20 @@ class Archivo:
             return None, handle_error(e)
         
 def open_adapter(facade, path, mode='r', encoding='utf-8') -> RTResult:
+    """
+    Adapter that exposes `Archivo.open()` to the Lunfardo runtime.
+
+    Converts Python values returned by the facade into Lunfardo runtime values
+    and packs them into a `Coso` structure of the form:
+
+        [file_id, error]
+
+    Where:
+        - `file_id` is a `Numero` on success or `Nada`.
+        - `error` is a `Chamuyo` containing the error name or `Nada`.
+
+    The result is wrapped inside an `RTResult` for interpreter consumption.
+    """
     result, error = facade.open(path, mode, encoding)
 
     file_value = Numero(result) if result is not None else Nada.nada
@@ -88,6 +221,17 @@ def open_adapter(facade, path, mode='r', encoding='utf-8') -> RTResult:
     )
 
 def read_adapter(facade, file_id) -> RTResult:
+    """
+    Adapter exposing `Archivo.read()` to the Lunfardo runtime.
+
+    Returns a `Coso` with the structure:
+
+        [content, error]
+
+    Where:
+        - `content` is a `Chamuyo` with the file contents or `Nada`.
+        - `error` is a `Chamuyo` containing the error name or `Nada`.
+    """
     result, error = facade.read(file_id)
 
     content_value = Chamuyo(result) if result is not None else Nada.nada
@@ -98,6 +242,17 @@ def read_adapter(facade, file_id) -> RTResult:
     )
 
 def write_adapter(facade, file_id, content) -> RTResult:
+    """
+    Adapter exposing `Archivo.write()` to the Lunfardo runtime.
+
+    Returns a `Coso` with the structure:
+
+        [Nada, error]
+
+    The first position is always `Nada` since write operations do not produce
+    a value. If an error occurs, the second position contains the error name
+    as `Chamuyo`.
+    """
     _, error = facade.write(file_id, content)
 
     error_value = Chamuyo(error.name.lower()) if error is not None else Nada.nada
@@ -106,6 +261,16 @@ def write_adapter(facade, file_id, content) -> RTResult:
     )
 
 def close_adapter(facade, file_id) -> RTResult:
+    """
+    Adapter exposing `Archivo.close()` to the Lunfardo runtime.
+
+    Returns a `Coso` with the structure:
+
+        [Nada, error]
+
+    The first value is always `Nada`. If the close operation fails, the second
+    value contains the error name as `Chamuyo`.
+    """
     _, error = facade.close(file_id)
 
     error_value = Chamuyo(error.name.lower()) if error is not None else Nada.nada

--- a/src/builtin/lib/archivos.py
+++ b/src/builtin/lib/archivos.py
@@ -1,0 +1,115 @@
+from src.rtresult import RTResult
+from src.lunfardo_types import Numero, Chamuyo, Nada, Coso
+from typing import IO, Any
+from enum import Enum, auto
+
+class Error(Enum):
+    ARCHIVO_NO_ENCONTRADO = auto()
+    BARDO_DE_PERMISO = auto()
+    ES_UN_DIRECTORIO = auto()
+    BARDO_DE_VALOR = auto()
+    BARDO_DE_TIPO = auto()
+    BARDO_UNICODE_DECODE = auto()
+    BARDO_UNICODE_ENCODE = auto()
+    BARDO_DE_IO = auto()
+    BARDO_DE_SISTEMA = auto()
+
+def handle_error(error: Exception) -> Error:
+    if isinstance(error, FileNotFoundError):
+        return Error.ARCHIVO_NO_ENCONTRADO
+    elif isinstance(error, PermissionError):
+        return Error.BARDO_DE_PERMISO
+    elif isinstance(error, IsADirectoryError):
+        return Error.ES_UN_DIRECTORIO
+    elif isinstance(error, ValueError):
+        return Error.BARDO_DE_VALOR
+    elif isinstance(error, TypeError):
+        return Error.BARDO_DE_TIPO
+    elif isinstance(error, UnicodeDecodeError):
+        return Error.BARDO_UNICODE_DECODE
+    elif isinstance(error, UnicodeEncodeError):
+        return Error.BARDO_UNICODE_ENCODE
+    elif isinstance(error, IOError):
+        return Error.BARDO_DE_IO
+    
+    return Error.BARDO_DE_SISTEMA
+
+class Archivo:
+
+    def __init__(self):
+        self.open_files: dict[int, IO[Any]] = {}
+        self.current_id: int = 0
+
+    def open(self, path: str, mode: str = 'r', encoding: str = 'utf-8') -> tuple[int | None, Error | None]:
+        result = None
+        try:
+            archivo = open(path, mode, encoding=encoding)
+            self.open_files[self.current_id] = archivo
+            self.current_id += 1
+            result = self.current_id - 1
+            return result, None
+        except Exception as e:
+            return None, handle_error(e)
+
+    def read(self, file_id) -> tuple[str | None, Error | None]:
+        result = None
+        try:
+            archivo = self.open_files[file_id]
+            result = archivo.read()
+            return result, None
+        except Exception as e:
+            return None, handle_error(e)
+
+    def write(self, file_id, content: str) -> tuple[None, Error | None]:
+        try:
+            archivo = self.open_files[file_id]
+            archivo.write(content)
+            return None, None
+        except Exception as e:
+            return None, handle_error(e)
+
+    def close(self, file_id) -> tuple[None, Error | None]:
+        try:
+            archivo = self.open_files[file_id]
+            archivo.close()
+            del self.open_files[file_id]
+            return None, None
+        except Exception as e:
+            return None, handle_error(e)
+        
+def open_adapter(facade, path, mode='r', encoding='utf-8') -> RTResult:
+    result, error = facade.open(path, mode, encoding)
+
+    file_value = Numero(result) if result is not None else Nada.nada
+    error_value = Chamuyo(error.name.lower()) if error is not None else Nada.nada
+
+    return RTResult().success(
+        Coso([file_value, error_value])
+    )
+
+def read_adapter(facade, file_id) -> RTResult:
+    result, error = facade.read(file_id)
+
+    content_value = Chamuyo(result) if result is not None else Nada.nada
+    error_value = Chamuyo(error.name.lower()) if error is not None else Nada.nada
+
+    return RTResult().success(
+        Coso([content_value, error_value])
+    )
+
+def write_adapter(facade, file_id, content) -> RTResult:
+    _, error = facade.write(file_id, content)
+
+    error_value = Chamuyo(error.name.lower()) if error is not None else Nada.nada
+    return RTResult().success(
+        Coso([Nada.nada, error_value])
+    )
+
+def close_adapter(facade, file_id) -> RTResult:
+    _, error = facade.close(file_id)
+
+    error_value = Chamuyo(error.name.lower()) if error is not None else Nada.nada
+
+    return RTResult().success(
+        Coso([Nada.nada, error_value])
+    )

--- a/src/builtin/lib/archivos.py
+++ b/src/builtin/lib/archivos.py
@@ -120,12 +120,12 @@ class Archivo:
         except Exception as e:
             return None, handle_error(e)
 
+    def read(self, file_id: int) -> tuple[str | None, Error | None]:
         """
         Read the entire contents of an open file.
 
         The file must have been previously opened with `open()`.
 
-    def read(self, file_id) -> tuple[str | None, Error | None]:
         Parameters
         ----------
         file_id
@@ -145,13 +145,13 @@ class Archivo:
         except Exception as e:
             return result, handle_error(e)
 
+    def write(self, file_id: int, content: str) -> tuple[None, Error | None]:
         """
         Write text content to an open file.
 
         The behavior depends on the mode used when opening the file
         (e.g. overwrite or append).
 
-    def write(self, file_id, content: str) -> tuple[None, Error | None]:
         Parameters
         ----------
         file_id
@@ -171,7 +171,7 @@ class Archivo:
         except Exception as e:
             return None, handle_error(e)
 
-    def close(self, file_id) -> tuple[None, Error | None]:
+    def close(self, file_id: int) -> tuple[None, Error | None]:
         """
         Close an open file and remove it from the runtime registry.
 
@@ -196,7 +196,7 @@ class Archivo:
         except Exception as e:
             return None, handle_error(e)
         
-def open_adapter(facade, path, mode='r', encoding='utf-8') -> RTResult:
+def open_adapter(facade: Archivo, path: str, mode: str = 'r', encoding: str = 'utf-8') -> RTResult:
     """
     Adapter that exposes `Archivo.open()` to the Lunfardo runtime.
 
@@ -220,7 +220,7 @@ def open_adapter(facade, path, mode='r', encoding='utf-8') -> RTResult:
         Coso([file_value, error_value])
     )
 
-def read_adapter(facade, file_id) -> RTResult:
+def read_adapter(facade: Archivo, file_id: int) -> RTResult:
     """
     Adapter exposing `Archivo.read()` to the Lunfardo runtime.
 
@@ -241,7 +241,7 @@ def read_adapter(facade, file_id) -> RTResult:
         Coso([content_value, error_value])
     )
 
-def write_adapter(facade, file_id, content) -> RTResult:
+def write_adapter(facade: Archivo, file_id: int, content: str) -> RTResult:
     """
     Adapter exposing `Archivo.write()` to the Lunfardo runtime.
 
@@ -260,7 +260,7 @@ def write_adapter(facade, file_id, content) -> RTResult:
         Coso([Nada.nada, error_value])
     )
 
-def close_adapter(facade, file_id) -> RTResult:
+def close_adapter(facade: Archivo, file_id: int) -> RTResult:
     """
     Adapter exposing `Archivo.close()` to the Lunfardo runtime.
 

--- a/src/chusma.py
+++ b/src/chusma.py
@@ -1,7 +1,7 @@
-from .context import Context
-from .interpreter import Interpreter
-from .lunfardo_types import Chamuyo, Curro
-from .rtresult import RTResult
+from src.context import Context
+from src.interpreter import Interpreter
+from src.lunfardo_types import Chamuyo, Curro
+from src.rtresult import RTResult
 
 class Chusma:
     TITLE = "Chusmeando"

--- a/src/constants/builtins.py
+++ b/src/constants/builtins.py
@@ -1,4 +1,5 @@
 BUILTINS = [
     "gualichos",
-    "lacompu"
+    "lacompu",
+    "archivos",
 ]

--- a/src/errors/errors.py
+++ b/src/errors/errors.py
@@ -134,3 +134,45 @@ class FileNotFoundBardo(RTError):
         super().__init__(pos_start, pos_end, f"Uy que rompimo! No pudimos abrir el archivo '{details}'\n El archivo no existe.", context)
         self.error_name = "[Archivo no encontrado]"
         self.name = "archivo_no_encontrado"
+
+class PermissionDeniedBardo(RTError):
+
+    def __init__(self, pos_start, pos_end, details, context) -> None:
+        super().__init__(pos_start, pos_end, f"Primero preocupate de poner bien los permisos así no perdemos tiempo, sabés? {details}", context)
+        self.error_name = "[Bardo de permiso]"
+        self.name = "bardo_de_permiso"
+
+class IsADirectoryBardo(RTError):
+
+    def __init__(self, pos_start, pos_end, details, context) -> None:
+        super().__init__(pos_start, pos_end, f"Es un directorio capo, sabés la diferencia? {details}", context)
+        self.error_name = "[Es un directorio]"
+        self.name = "es_un_directorio"
+
+class UnicodeDecodeBardo(RTError):
+
+    def __init__(self, pos_start, pos_end, details, context) -> None:
+        super().__init__(pos_start, pos_end, f"Empezá a aprender plomería {details}", context)
+        self.error_name = "[Bardo de decodificación unicode]"
+        self.name = "bardo_unicode_decode"
+
+class UnicodeEncodeBardo(RTError):
+
+    def __init__(self, pos_start, pos_end, details, context) -> None:
+        super().__init__(pos_start, pos_end, f"Evidentemente la IA lo tiene bastante fácil para dominar el mercado de programación {details}", context)
+        self.error_name = "[Bardo de encodificación unicode]"
+        self.name = "bardo_unicode_encode"
+
+class IOBardo(RTError):
+
+    def __init__(self, pos_start, pos_end, details, context) -> None:
+        super().__init__(pos_start, pos_end, f"Vos más que bardos tenés problemitas... {details}", context)
+        self.error_name = "[Bardo de I/O]"
+        self.name = "bardo_de_io"
+
+class OSBardo(RTError):
+
+    def __init__(self, pos_start, pos_end, details, context) -> None:
+        super().__init__(pos_start, pos_end, f"Sos tonto o usás Windows? {details}", context)
+        self.error_name = "[Bardo de sistema]"
+        self.name = "bardo_de_sistema"

--- a/src/interpreter.py
+++ b/src/interpreter.py
@@ -1223,7 +1223,13 @@ class Interpreter:
             ZeroDivisionBardo,
             InvalidKeyBardo,
             InvalidIndexBardo,
-            FileNotFoundBardo
+            FileNotFoundBardo,
+            PermissionDeniedBardo,
+            IsADirectoryBardo,
+            UnicodeDecodeBardo,
+            UnicodeEncodeBardo,
+            IOBardo,
+            OSBardo
         )
 
         AVAILABLE_BARDOS = {
@@ -1235,7 +1241,13 @@ class Interpreter:
             'division_por_cero': ZeroDivisionBardo,
             'bardo_de_clave': InvalidKeyBardo,
             'bardo_de_indice': InvalidIndexBardo,
-            'archivo_no_encontrado': FileNotFoundBardo
+            'archivo_no_encontrado': FileNotFoundBardo,
+            'bardo_de_permiso': PermissionDeniedBardo,
+            'es_un_directorio': IsADirectoryBardo,
+            'bardo_unicode_decode': UnicodeDecodeBardo,
+            'bardo_unicode_encode': UnicodeEncodeBardo,
+            'bardo_de_io': IOBardo,
+            'bardo_de_sistema': OSBardo
         }
         
         bardo_msg = res.register(self.visit(node.bardo_msg_node, context))

--- a/src/interpreter.py
+++ b/src/interpreter.py
@@ -644,16 +644,16 @@ class Interpreter:
         from .lunfardo_types.laburo import Curro, Laburo
         
         value_to_call = res.register(self.visit(node.node_to_call, context))
-        if not isinstance(value_to_call, BaseLaburo):
+        if res.should_return():
+            return res
+        
+        """ if not isinstance(value_to_call, (Curro, Laburo)):
             return res.failure(InvalidTypeBardo(
                 node.pos_start,
                 node.pos_end,
                 f"{value_to_call} no existe o no es un laburo o curro que se pueda llamar",
                 context
-            ))
-        
-        if res.should_return():
-            return res
+            )) """
         
         value_to_call = value_to_call.copy().set_pos(node.pos_start, node.pos_end)
 

--- a/src/interpreter.py
+++ b/src/interpreter.py
@@ -100,7 +100,7 @@ class Interpreter:
         Returns:
             RTResult: A runtime result containing the Chamuyo value.
         """
-        from .lunfardo_types import Chamuyo
+        from src.lunfardo_types import Chamuyo
         
         return RTResult().success(
             Chamuyo(node.tok.value).set_context(context).set_pos(node.pos_start, node.pos_end)
@@ -641,7 +641,7 @@ class Interpreter:
         res = RTResult()
         args = []
 
-        from .lunfardo_types.laburo import BaseLaburo
+        from .lunfardo_types.laburo import Curro, Laburo
         
         value_to_call = res.register(self.visit(node.node_to_call, context))
         if not isinstance(value_to_call, BaseLaburo):
@@ -720,8 +720,8 @@ class Interpreter:
             - The object itself is passed as the first argument to the method.
             - All other arguments are evaluated in the current context before being passed to the method.
         """
-        from .lunfardo_types import Chamuyo
-        from .lunfardo_types.cheto import ChetoInstance
+        from src.lunfardo_types import Chamuyo
+        from src.lunfardo_types.cheto import ChetoInstance
 
         res = RTResult()
 
@@ -1177,7 +1177,7 @@ class Interpreter:
         if res.should_return():
             return res
         
-        from .lunfardo_types import Chamuyo
+        from src.lunfardo_types import Chamuyo
         if isinstance(module, Chamuyo):
             module.value += ".lunf"
         import_value = res.register(ejecutar_func.execute([module], context, self))
@@ -1214,7 +1214,7 @@ class Interpreter:
     
     def visit_BardeaNode(self, node: BardeaNode, context: Context) -> RTResult:
         res = RTResult()
-        from errors import (
+        from src.errors import (
             InvalidTypeBardo,
             MaxRecursionBardo,
             AttributeBardo,

--- a/src/library_registry.py
+++ b/src/library_registry.py
@@ -1,6 +1,6 @@
-from .errors.errors import RTError
-from .rtresult import RTResult
-from .lunfardo_types import Nada
+from src.errors.errors import RTError
+from src.rtresult import RTResult
+from src.lunfardo_types import Nada
 
 LIBRARY_HANDLERS = {}
 

--- a/src/library_registry.py
+++ b/src/library_registry.py
@@ -97,6 +97,35 @@ def init_lacompu(module_context, node, context):
     
     return res.success(Nada.nada)
 
+def init_archivos(module_context, node, context):
+    res = RTResult()
+
+    try:
+        from src.builtin.lib.archivos import (
+            Archivo, open_adapter, read_adapter, write_adapter, close_adapter
+        )
+
+        wrapper_instance = Archivo()
+        from src.lunfardo_types import Curro
+        archivos_functions = {
+            "open": lambda exec_ctx: open_adapter(wrapper_instance, exec_ctx.symbol_table.get("ruta").value, exec_ctx.symbol_table.get("modo").value, exec_ctx.symbol_table.get("codificacion").value),
+            "read": lambda exec_ctx: read_adapter(wrapper_instance, exec_ctx.symbol_table.get("archivo_id").value),
+            "write": lambda exec_ctx: write_adapter(wrapper_instance, exec_ctx.symbol_table.get("archivo_id").value, exec_ctx.symbol_table.get("contenido").value),
+            "close": lambda exec_ctx: close_adapter(wrapper_instance, exec_ctx.symbol_table.get("archivo_id").value)
+        }
+
+        for name, func in archivos_functions.items():
+            curro_instance = Curro(name, func)
+            module_context.symbol_table.set(name, curro_instance)
+    
+    except ImportError as e:
+        return res.failure(RTError(node.pos_start, node.pos_end, f"Bardo al importar la librería 'archivos': {str(e)}", context))
+    except AttributeError:
+        return res.failure(RTError(node.pos_start, node.pos_end, "Bardo en la librería 'archivos'", context))
+    
+    return res.success(Nada.nada)
+
 
 register_library_handler("gualichos", init_gualichos)
 register_library_handler("lacompu", init_lacompu)
+register_library_handler("archivos", init_archivos)

--- a/src/library_registry.py
+++ b/src/library_registry.py
@@ -14,7 +14,7 @@ def get_library_handler(lib_name: str):
 def init_gualichos(module_context, node, context):
     res = RTResult()
     try:
-        from builtin.lib.gualichos import (
+        from src.builtin.lib.gualichos import (
             Gualichos, addstr_adapter, getch_adapter, clear_adapter, 
             quit_adapter, border_adapter, getkey_adapter, getstr_adapter, 
             echo_adapter, refresh_adapter, erase_adapter, addch_adapter,
@@ -22,7 +22,7 @@ def init_gualichos(module_context, node, context):
             cbreak_adapter, keypad_adapter, getmaxyx_adapter, nocbreak_adapter
         )
         wrapper_instance = Gualichos()
-        from lunfardo_types import Curro
+        from src.lunfardo_types import Curro
         gualichos_functions = {
             "noecho": lambda exec_ctx: noecho_adapter(wrapper_instance),
             "cbreak": lambda exec_ctx: cbreak_adapter(wrapper_instance),
@@ -58,7 +58,7 @@ def init_lacompu(module_context, node, context):
     res = RTResult()
 
     try:
-        from builtin.lib.lacompu import (
+        from src.builtin.lib.lacompu import (
             LaCompu, chdir_adapter, getcwd_adapter, getenv_adapter, listdir_adapter,
             mkdir_adapter, makedirs_adapter, remove_adapter, rmdir_adapter, rename_adapter,
             system_adapter, name_adapter, environ_adapter, sep_adapter, pathsep_adapter,
@@ -66,7 +66,7 @@ def init_lacompu(module_context, node, context):
         )
 
         wrapper_instance = LaCompu()
-        from lunfardo_types import Curro
+        from src.lunfardo_types import Curro
         la_compu_functions = {
             "chdir": lambda exec_ctx: chdir_adapter(wrapper_instance, exec_ctx.symbol_table.get("ruta").value),
             "getcwd": lambda exec_ctx: getcwd_adapter(wrapper_instance),

--- a/src/lunfardo.py
+++ b/src/lunfardo.py
@@ -8,12 +8,12 @@ import sys
 from pathlib import Path
 from typing import Tuple
 from os import getcwd
-from .lexer import Lexer
-from .lunfardo_parser import Parser
-from .lunfardo_types import Curro, Boloodean, Nada
-from .interpreter import Interpreter
-from .symbol_table import SymbolTable
-from .context import Context
+from src.lexer import Lexer
+from src.lunfardo_parser import Parser
+from src.lunfardo_types import Curro, Boloodean, Nada
+from src.interpreter import Interpreter
+from src.symbol_table import SymbolTable
+from src.context import Context
 
 class Lunfardo:
 

--- a/src/lunfardo.py
+++ b/src/lunfardo.py
@@ -121,7 +121,7 @@ class Lunfardo:
             try:
                 text = input(f"{default_color}Lunfardo > ")
             except KeyboardInterrupt:
-                print("\nExiting REPL.")
+                print("\nSaliendo del REPL. ¡Hasta luego!")
                 break
 
             if text.strip() == "":

--- a/src/lunfardo_parser.py
+++ b/src/lunfardo_parser.py
@@ -1923,7 +1923,13 @@ class Parser:
             'division_por_cero',
             'bardo_de_clave',
             'bardo_de_indice',
-            'archivo_no_encontrado'
+            'archivo_no_encontrado',
+            'bardo_de_permiso',
+            'es_un_directorio',
+            'bardo_unicode_decode',
+            'bardo_unicode_enconde',
+            'bardo_de_io',
+            'bardo_de_sistema'
         )):
             return res.failure(
                 InvalidSyntaxBardo(
@@ -2002,7 +2008,14 @@ class Parser:
             'bardo_de_tipo',
             'bardo_de_indice',
             'bardo_de_clave',
-            'bardo_de_valor'
+            'bardo_de_valor',
+            'bardo_de_permiso',
+            'es_un_directorio',
+            'bardo_unicode_decode',
+            'bardo_unicode_enconde',
+            'bardo_de_io',
+            'bardo_de_sistema',
+            'archivo_no_encontrado'
         )):
             return res.failure(
                 InvalidSyntaxBardo(

--- a/src/lunfardo_types/__init__.py
+++ b/src/lunfardo_types/__init__.py
@@ -1,13 +1,13 @@
 from typing import Union
 
-from .numero import Numero
-from .boloodean import Boloodean
-from .nada import Nada
-from .laburo import Laburo, Curro
-from .chamuyo import Chamuyo
-from .coso import Coso
-from .mataburros import Mataburros
-from .cheto import Cheto
+from src.lunfardo_types.numero import Numero
+from src.lunfardo_types.boloodean import Boloodean
+from src.lunfardo_types.nada import Nada
+from src.lunfardo_types.laburo import Laburo, Curro
+from src.lunfardo_types.chamuyo import Chamuyo
+from src.lunfardo_types.coso import Coso
+from src.lunfardo_types.mataburros import Mataburros
+from src.lunfardo_types.cheto import Cheto
 
 LUNFARDO_TYPES = Union[Numero, Boloodean, Nada, Laburo, Curro, Chamuyo, Coso, Mataburros, Cheto]
 VALUE_TYPES = Union[Numero, Boloodean, Nada, Chamuyo]

--- a/src/lunfardo_types/laburo.py
+++ b/src/lunfardo_types/laburo.py
@@ -842,7 +842,7 @@ class Curro(BaseLaburo):
                     )
                 )
 
-        from lunfardo import Lunfardo
+        from src.lunfardo import Lunfardo
 
         result, error = Lunfardo().execute(file_path, script, str(current_dir), parent_context=exec_ctx)
 

--- a/src/lunfardo_types/laburo.py
+++ b/src/lunfardo_types/laburo.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 from .value import Value
 from .boloodean import Boloodean
 from src.rtresult import RTResult
-#from src.interpreter import Interpreter
 from src.symbol_table import SymbolTable
 from src.context import Context
 from src.errors import RTError, InvalidTypeBardo

--- a/src/lunfardo_types/laburo.py
+++ b/src/lunfardo_types/laburo.py
@@ -260,7 +260,7 @@ class Curro(BaseLaburo):
     #########################################
 
     def exec_chamu(self, exec_ctx: Context) -> RTResult:
-        from . import Chamuyo, Numero, Coso, Nada
+        from src.lunfardo_types import Chamuyo, Numero, Coso, Nada
         from errors import InvalidTypeBardo
 
         value = exec_ctx.symbol_table.get("value") if exec_ctx and exec_ctx.symbol_table else None
@@ -299,7 +299,7 @@ class Curro(BaseLaburo):
     exec_chamu.arg_names = ["value"]
 
     def exec_num(self, exec_ctx: Context) -> RTResult:
-        from . import Chamuyo, Numero, Nada
+        from src.lunfardo_types import Chamuyo, Numero, Nada
         from errors import InvalidTypeBardo, InvalidValueBardo
 
         value = exec_ctx.symbol_table.get("value") if exec_ctx and exec_ctx.symbol_table else None
@@ -366,7 +366,7 @@ class Curro(BaseLaburo):
     exec_matear.arg_names = ["value"]
 
     def exec_morfar(self, exec_ctx: Context) -> RTResult:
-        from . import Chamuyo
+        from src.lunfardo_types import Chamuyo
         from lunfardo_types import Nada
 
         _prefix = exec_ctx.symbol_table.get("value") if exec_ctx and exec_ctx.symbol_table else None
@@ -624,7 +624,7 @@ class Curro(BaseLaburo):
     exec_extender.arg_names = ["listA", "listB"]
 
     def exec_agarra_de(self, exec_ctx: Context) -> RTResult:
-        from . import Chamuyo, Numero, Mataburros, Nada
+        from src.lunfardo_types import Chamuyo, Numero, Mataburros, Nada
         from errors import InvalidTypeBardo
 
         dict_ = exec_ctx.symbol_table.get("dict") if exec_ctx and exec_ctx.symbol_table else None
@@ -659,7 +659,7 @@ class Curro(BaseLaburo):
     exec_agarra_de.arg_names = ["dict", "key"]
 
     def exec_metele_en(self, exec_ctx: Context) -> RTResult:
-        from . import Chamuyo, Numero, Mataburros, Nada
+        from src.lunfardo_types import Chamuyo, Numero, Mataburros, Nada
         from errors import InvalidTypeBardo
 
         dict_ = exec_ctx.symbol_table.get("dict") if exec_ctx and exec_ctx.symbol_table else None
@@ -692,7 +692,7 @@ class Curro(BaseLaburo):
     exec_metele_en.arg_names = ["dict", "key", "value"]
 
     def exec_borra_de(self, exec_ctx: Context) -> RTResult:
-        from . import Chamuyo, Numero, Mataburros, Nada
+        from src.lunfardo_types import Chamuyo, Numero, Mataburros, Nada
         from errors import InvalidTypeBardo, InvalidKeyBardo
 
         dict_ = exec_ctx.symbol_table.get("dict") if exec_ctx and exec_ctx.symbol_table else None
@@ -734,7 +734,7 @@ class Curro(BaseLaburo):
     exec_borra_de.arg_names = ["dict", "key"]
 
     def exec_existe_clave(self, exec_ctx: Context) -> RTResult:
-        from . import Chamuyo, Numero, Mataburros, Nada, Boloodean
+        from src.lunfardo_types import Chamuyo, Numero, Mataburros, Nada, Boloodean
         from errors import InvalidTypeBardo
 
         dict_ = exec_ctx.symbol_table.get("dict") if exec_ctx and exec_ctx.symbol_table else None
@@ -797,7 +797,7 @@ class Curro(BaseLaburo):
     exec_longitud.arg_names = ["arg"]
 
     def exec_ejecutar(self, exec_ctx: Context) -> RTResult:
-        from . import Chamuyo
+        from src.lunfardo_types import Chamuyo
         from errors import InvalidTypeBardo, FileNotFoundBardo
 
         fn = exec_ctx.symbol_table.get("fn") if exec_ctx and exec_ctx.symbol_table else None
@@ -888,7 +888,7 @@ class Curro(BaseLaburo):
     exec_contexto_global.arg_names = ['local']
 
     def exec_asciiAchamu(self, exec_ctx: Context) -> RTResult:
-        from . import Chamuyo, Numero
+        from src.lunfardo_types import Chamuyo, Numero
         from errors import InvalidTypeBardo
 
         code = exec_ctx.symbol_table.get("ascii_code") if exec_ctx and exec_ctx.symbol_table else None

--- a/src/lunfardo_types/laburo.py
+++ b/src/lunfardo_types/laburo.py
@@ -844,7 +844,7 @@ class Curro(BaseLaburo):
 
         from src.lunfardo import Lunfardo
 
-        result, error = Lunfardo().execute(file_path, script, str(current_dir), parent_context=exec_ctx)
+        result, error, _ = Lunfardo().execute(file_path, script, str(current_dir), parent_context=exec_ctx)
 
         if error:
             return RTResult().failure(

--- a/src/runtime/op_registry.py
+++ b/src/runtime/op_registry.py
@@ -15,7 +15,7 @@ class OperatorRegistry:
                 pos_start=left.pos_start,
                 pos_end=right.pos_end,
                 details=f"Operación '{op}' no soportada entre "
-                f"{left} y {right}",
+                f"{type(left).__name__} y {type(right).__name__}",
                 context=ctx,
             )
         


### PR DESCRIPTION
## Summary

This merge introduces the initial built-in file I/O support for Lunfardo along with several fixes, refactors, and maintenance improvements.

---

## Features

- Added the built-in library `archivos` for basic file I/O:
  - `abrir_archivo()` — opens a file
  - `leer_archivo()` — reads text content from an open file
  - `escribir_archivo()` — writes text content to an open file
  - `cerrar_archivo()` — closes an open file
- Added a private helper method to retrieve file handles internally.
- Introduced new **bardos** (error types) related to file operations.

---

## Fixes

- Corrected relative import paths.
- Replaced broken relative imports with absolute `src` imports to avoid namespace conflicts.
- Fixed assignment to correctly unpack the third return value from `execute()`.
- Improved error messages by displaying operand **type names** instead of object values.

---

## Refactors

- Adjusted error-path behavior in `open()` to return the `result` variable for consistency.
- Reordered return propagation checks before callable validation in the interpreter.
- Temporarily disabled callable type validation due to unresolved issues.

---

## Maintenance

- Added type hints across updated code.
- Added missing docstrings.
- Removed commented imports.
- Updated REPL exit message wording.