### PR TITLE
Bugfix/builtin library path resolution

### DIFF
--- a/src/lunfardo.py
+++ b/src/lunfardo.py
@@ -100,14 +100,19 @@ class Lunfardo:
 
         return result.value, result.error, interpreter
 
-    def execute_file(self, script_path: str) -> None:
+    def execute_file(self, script_path: str, _debug: bool = False, _interp: type[Interpreter] | None = None) -> None | Tuple:
         """Execute a Lunfardo file."""
         try:
             with open(script_path, "r", encoding="utf-8") as f:
                 code = f.read()
             file_path = Path(script_path)
-            _, error, _ = self.execute(fn=file_path, text=code, cwd=file_path.parent)
-
+            
+            if _debug and _interp:
+                result, error, interpreter = self.execute(fn=file_path, text=code, cwd=file_path.parent, interpreter_cls=_interp)
+                return result, error, interpreter
+            
+            result, error, interpreter = self.execute(fn=file_path, text=code, cwd=file_path.parent)
+               
             if error:
                 print(error.as_string())
 

--- a/src/lunfardo_types/laburo.py
+++ b/src/lunfardo_types/laburo.py
@@ -822,11 +822,8 @@ class Curro(BaseLaburo):
             with open(file_path, "r", encoding='utf-8') as f:
                 script = f.read()
         except FileNotFoundError:
-            parent_dir = current_dir
-            while parent_dir.name != 'src':
-                parent_dir = parent_dir.parent
-            
-            file_path = parent_dir / 'builtin' / fn
+            current_dir = Path(os.path.dirname(os.path.abspath(__file__))).parent
+            file_path = current_dir / 'builtin' / fn
 
             try:
                 with open(file_path, "r", encoding='utf-8') as f:

--- a/src/rtresult.py
+++ b/src/rtresult.py
@@ -63,3 +63,12 @@ class RTResult:
             or self.loop_should_continue
             or self.loop_should_break
         )
+    
+    def __str__(self) -> str:
+        return (
+            f"value={self.value}, "
+            f"error={self.error}, "
+            f"func_return_value={self.func_return_value}, "
+            f"loop_should_continue={self.loop_should_continue}, "
+            f"loop_should_break={self.loop_should_break}"
+        )

--- a/tests/path_resolution.lunf
+++ b/tests/path_resolution.lunf
@@ -1,0 +1,5 @@
+dame lacompu
+dame path_resolution_same_dir
+
+matear(test())
+devolver "Separador: " + separador()

--- a/tests/path_resolution_same_dir.lunf
+++ b/tests/path_resolution_same_dir.lunf
@@ -1,0 +1,3 @@
+laburo test()
+    devolver "test"
+chau

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -9,11 +9,17 @@ class InterpreterTester(Interpreter):
 
     def __init__(self):
         super().__init__()
-        self.captured_result = None
+        self.captured_results = None
+        self.return_values = []
 
     def visit(self, node, context):
         result = super().visit(node, context)
-        self.captured_result = result
+        self.captured_results = result
+        return result
+    
+    def visit_DevolverNode(self, node, context):
+        result = super().visit_DevolverNode(node, context)
+        self.return_values.append(result)
         return result
 
     
@@ -84,7 +90,7 @@ def test_interpreter_si_declaracion(lunfardo_instance: Lunfardo):
     '''
     result, error, interp = lunfardo_instance.execute("<test>", code, interpreter_cls = InterpreterTester)
     assert error is None
-    assert interp.captured_result.func_return_value.value == 1
+    assert interp.return_values[-1].func_return_value.value == 1
 
 def test_interpreter_si_sino_declaracion(lunfardo_instance: Lunfardo):
     code = '''
@@ -96,7 +102,7 @@ def test_interpreter_si_sino_declaracion(lunfardo_instance: Lunfardo):
     '''
     result, error, interp = lunfardo_instance.execute("<test>", code, interpreter_cls = InterpreterTester)
     assert error is None
-    assert interp.captured_result.func_return_value.value == 2
+    assert interp.return_values[-1].func_return_value.value == 2
 
 def test_interpreter_bucle_para(lunfardo_instance: Lunfardo):
     code = '''
@@ -163,7 +169,7 @@ def test_interpreter_definicion_llamada_cheto(lunfardo_instance: Lunfardo):
     '''
     result, error, interp = lunfardo_instance.execute("<test>", code, interpreter_cls = InterpreterTester)
     assert error is None
-    assert result.elements[-1].value == 7.5
+    assert interp.return_values[-1].func_return_value.value == 7.5
 
 def test_interpreter_cheto_access_chain(lunfardo_instance: Lunfardo):
     code = '''
@@ -194,4 +200,4 @@ def test_interpreter_cheto_access_chain(lunfardo_instance: Lunfardo):
     '''
     result, error, interp = lunfardo_instance.execute("<test>", code, interpreter_cls = InterpreterTester)
     assert error is None
-    assert result.elements[-1].value == 7
+    assert interp.return_values[-1].func_return_value.value == 7

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -201,3 +201,11 @@ def test_interpreter_cheto_access_chain(lunfardo_instance: Lunfardo):
     result, error, interp = lunfardo_instance.execute("<test>", code, interpreter_cls = InterpreterTester)
     assert error is None
     assert interp.return_values[-1].func_return_value.value == 7
+
+def test_interpreter_path_resolution(lunfardo_instance: Lunfardo):
+    import os
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    result, error, interp = lunfardo_instance.execute_file(f"{current_dir}/path_resolution.lunf", _debug=True, _interp=InterpreterTester)
+    assert error is None
+    assert interp.return_values[0].func_return_value.value == 'test'
+    assert interp.return_values[-1].func_return_value.value == 'Separador: \\'


### PR DESCRIPTION
## Fixes

- Fixed an issue where built-in libraries could not be imported when executing Lunfardo scripts located outside the `examples` directory.

---

## Features

- Added a **debug mode** to `execute_file()` that allows returning the interpreter instance used during execution.  
  This enables deeper inspection of interpreter state during testing and debugging.

- Implemented `__str__` representation for `RTResult` to improve debugging output and readability.

- Added `visit_DevolverNode` support to `InterpreterTester`.
  - Updated related tests using the `devolver` keyword.

---

## Testing

- Extended the test suite to cover the built-in import path issue.
- Updated tests interacting with `devolver` to reflect the new interpreter tester capabilities.